### PR TITLE
fix(format-date): string format date tojson output yyyy-mm-dd string …

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.2
+- Type string with format 'date' produce yyyy-MM-dd when using toJson from Retrofit ([documentation](https://swagger.io/docs/specification/data-models/data-types/#format))
+
 ## 0.9.1
 - Use ` JsonEnum ` and ` JsonValue ` on generated enum
 

--- a/swagger_parser/lib/src/utils/utils.dart
+++ b/swagger_parser/lib/src/utils/utils.dart
@@ -49,6 +49,13 @@ String fileImport(UniversalComponentClass dataClass) =>
         ? "import 'dart:io';\n\n"
         : '';
 
+String intlImport(UniversalComponentClass dataClass) =>
+    dataClass.parameters.any(
+      (p) => p.format == 'date',
+    )
+        ? "import 'package:intl/intl.dart';\n"
+        : '';
+
 void introMessage() {
   stdout.writeln('''
   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -201,6 +201,7 @@ class ClassName with _$ClassName {
       const expectedContents = r'''
 import 'dart:io';
 
+import 'package:intl/intl.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'class_name.g.dart';
@@ -230,6 +231,7 @@ class ClassName {
   final double floatNumberType;
   final String stringType;
   final File binaryStringType;
+  @JsonKey(toJson: _formatDateToJson)
   final DateTime dateStringType;
   final DateTime dateTimeStringType;
   final File fileType;
@@ -238,6 +240,10 @@ class ClassName {
   final Another anotherType;
 
   Map<String, dynamic> toJson() => _$ClassNameToJson(this);
+}
+
+String _formatDateToJson(DateTime dateTime) {
+  return DateFormat('yyyy-MM-dd').format(dateTime);
 }
 ''';
       expect(filledContent.contents, expectedContents);


### PR DESCRIPTION
when swagger_parser generate client and classes from 
```
{
  "type": "string",
  "format": "date"
}
```

REST API call should generate json with yyyy-MM-dd as date

![image](https://user-images.githubusercontent.com/10436754/228973957-abd64bb3-e761-486e-b22c-335b9f6b7d60.png)