### PR TITLE
fixes on enum generation, multiline comments support and swagger v2 body params

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -33,7 +33,11 @@ String _jsonValue(String type, String item) => '''
   @JsonValue(${type == 'string' ? "'$item'" : item})
   ${_valuePrefixForEnumItems(type, item)}''';
 
-String _valuePrefixForEnumItems(String type, String item) =>
-    type != 'string' || dartKeywords.contains(item.toCamel)
-        ? 'value ${item.toCamel}'.toCamel
-        : item.toCamel;
+String _valuePrefixForEnumItems(String type, String item) {
+  final startsWithNumber = RegExp(r'^\d');
+  return type != 'string' ||
+          dartKeywords.contains(item.toCamel) ||
+          startsWithNumber.hasMatch(item)
+      ? 'value ${item.toCamel}'.toCamel
+      : item.toCamel;
+}

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -334,7 +334,7 @@ class OpenApiParser {
               (e) => e.name == (rawParameter[_inConst].toString()),
             ),
             type: typeWithImport.type,
-            name: rawParameter[_nameConst] == _bodyConst
+            name: rawParameter[_inConst] == _bodyConst
                 ? null
                 : rawParameter[_nameConst].toString(),
           ),
@@ -615,12 +615,16 @@ class OpenApiParser {
       // `enum`
       final newName = name ?? _uniqueName;
       final items = (map[_enumConst] as List).map((e) => e.toString()).toSet();
+
+      final defaultValue = map[_defaultConst] == null
+          ? null
+          : '${newName.toPascal}.${map[_defaultConst].toString().toCamel}';
       _enumClasses.add(
         UniversalEnumClass(
           name: newName,
           type: map[_typeConst].toString(),
           items: items,
-          defaultValue: map[_defaultConst]?.toString(),
+          defaultValue: defaultValue,
           description: map[_descriptionConst]?.toString(),
         ),
       );
@@ -636,7 +640,7 @@ class OpenApiParser {
               ? map[_formatConst].toString()
               : null,
           jsonKey: newName,
-          defaultValue: map[_defaultConst]?.toString(),
+          defaultValue: defaultValue,
           isRequired: isRequired,
         ),
         import: newName,

--- a/swagger_parser/lib/src/utils/utils.dart
+++ b/swagger_parser/lib/src/utils/utils.dart
@@ -18,7 +18,14 @@ String descriptionComment(String? description, {String tab = ''}) {
   if (description == null || description.isEmpty) {
     return '';
   }
-  return '$tab/// $description\n';
+
+  final lineStart = RegExp('^(.*)', multiLine: true);
+  final result = description.replaceAllMapped(
+    lineStart,
+    (m) => '$tab/// ${m[1]}',
+  );
+
+  return '$result\n';
 }
 
 String ioImport(UniversalComponentClass dataClass) => dataClass.parameters

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1052,6 +1052,11 @@ class ClassName with _$ClassName {
           type: 'string',
           items: {'FALSE', 'for', 'do'},
         ),
+        UniversalEnumClass(
+          name: 'EnumNameStringWithLeadingNumbers',
+          type: 'string',
+          items: {'1itemOne', '2ItemTwo', '3item_three', '4ITEM-FOUR'},
+        ),
       ];
 
       const fillController = FillController();
@@ -1126,9 +1131,36 @@ const _$KeywordsNameEnumMap = {
   KeywordsName.valueDo: 'do',
 };
 ''';
+
+      const expectedContent3 = r'''
+import 'package:json_annotation/json_annotation.dart';
+
+@JsonEnum()
+enum EnumNameStringWithLeadingNumbers {
+  @JsonValue('1itemOne')
+  value1itemOne,
+  @JsonValue('2ItemTwo')
+  value2ItemTwo,
+  @JsonValue('3item_three')
+  value3itemThree,
+  @JsonValue('4ITEM-FOUR')
+  value4itemFour;
+
+  String toJson() => _$EnumNameStringWithLeadingNumbersEnumMap[this]!;
+}
+
+const _$EnumNameStringWithLeadingNumbersEnumMap = {
+  EnumNameStringWithLeadingNumbers.value1itemOne: '1itemOne',
+  EnumNameStringWithLeadingNumbers.value2ItemTwo: '2ItemTwo',
+  EnumNameStringWithLeadingNumbers.value3itemThree: '3item_three',
+  EnumNameStringWithLeadingNumbers.value4itemFour: '4ITEM-FOUR',
+};
+''';
+
       expect(files[0].contents, expectedContent0);
       expect(files[1].contents, expectedContent1);
       expect(files[2].contents, expectedContent2);
+      expect(files[3].contents, expectedContent3);
     });
 
     test('dart + freezed', () async {
@@ -1625,7 +1657,7 @@ data class ClassName(
           ),
           UniversalType(
             type: 'string',
-            description: 'List of data',
+            description: 'List of data\nThis data is a list',
             arrayDepth: 1,
             name: 'list',
           ),
@@ -1664,6 +1696,7 @@ class ClassName {
   final String megaMind;
   final Object emptyDescription;
   /// List of data
+  /// This data is a list
   final List<String> list;
 
   Map<String, dynamic> toJson() => _$ClassNameToJson(this);
@@ -1708,7 +1741,7 @@ class ClassName {
           ),
           UniversalType(
             type: 'string',
-            description: 'List of data',
+            description: 'List of data\nThis data is a list',
             arrayDepth: 1,
             name: 'list',
           ),
@@ -1736,6 +1769,7 @@ class ClassName with _$ClassName {
     required String megaMind,
     required Object emptyDescription,
     /// List of data
+    /// This data is a list
     required List<String> list,
     /// Default value
     @Default('str')


### PR DESCRIPTION
The branch contains the following fixes:
1. In swagger v2 generation, the body annotation was previously generated with the name as string parameter like this:
`@Body('name')` which breaks the generated code because the body annotation does not accept a string parameter. It is now generated as `@Body()`. #53
2. Added support for multiline description comment. Previously a description string of "First line\nNext line" would generate a comment for the first line only, now every line will be commented. #54
3. Fixed default value for enums passed as query parameters. Previosly the generated code was `@Query('unit') Unit unit = CELSIUS` but this is invalid in dart syntax, therefore enums default values are now generated as follows: `@Query('unit') Unit unit = Unit.celsius` #56
4. Fixed the generation of enums of type string but having items starting with a number (for example a value could be "404NotFound"). The generation now follows the same rule that is applied in case of integer enums. #55 
