### PR TITLE
updated retrofit dependency to v7.0.7

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+- Updated `retrofit_generator` dependency to [7.0.7](https://github.com/trevorwang/retrofit.dart/releases/tag/7.0.7) and consequently removed unused `.toJson()` generated methods in enums
+
 ## 1.1.0
 - Add regex replacement for generated class names
 - Fixed error with null raw parameter in OpenApi v2 ([#63](https://github.com/Carapacik/swagger_parser/issues/63))

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -35,7 +35,7 @@ dev_dependencies:
   # build_runner: ^2.3.3
   # freezed: ^2.3.5 # for freezed
   # json_serializable: ^6.6.2
-  # retrofit_generator: ^7.0.0
+  # retrofit_generator: ^7.0.7
   swagger_parser:
 ```
 

--- a/swagger_parser/example/pubspec.yaml
+++ b/swagger_parser/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   carapacik_lints: ^1.4.0
   freezed: ^2.3.5
   json_serializable: ^6.7.0
-  retrofit_generator: ^7.0.1+1
+  retrofit_generator: ^7.0.7
   swagger_parser:
     path:
       ../

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -15,16 +15,7 @@ import '${freezed ? 'package:freezed_annotation/freezed_annotation.dart' : 'pack
 ${descriptionComment(enumClass.description)}@JsonEnum()
 enum $className {
 ${enumClass.items.map((e) => _jsonValue(enumClass.type, e)).join(',\n')};
-
-  ${enumClass.type.toDartType()} toJson() => _\$${className}EnumMap[this]!;
 }
-
-const _\$${className}EnumMap = {
-  ${enumClass.items.map(
-            (e) => '$className.${prefixForEnumItems(enumClass.type, e)}: '
-                '${enumClass.type.quoterForStringType()}$e${enumClass.type.quoterForStringType()}',
-          ).join(',\n  ')},
-};
 ''';
 }
 

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 homepage: https://omega-r.com
 topics:

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1064,7 +1064,7 @@ class ClassName with _$ClassName {
       for (final enumClass in dataClasses) {
         files.add(fillController.fillDtoContent(enumClass));
       }
-      const expectedContent0 = r'''
+      const expectedContent0 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1075,18 +1075,10 @@ enum EnumName {
   value2,
   @JsonValue(3)
   value3;
-
-  int toJson() => _$EnumNameEnumMap[this]!;
 }
-
-const _$EnumNameEnumMap = {
-  EnumName.value1: 1,
-  EnumName.value2: 2,
-  EnumName.value3: 3,
-};
 ''';
 
-      const expectedContent1 = r'''
+      const expectedContent1 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1099,18 +1091,9 @@ enum EnumNameString {
   itemThree,
   @JsonValue('ITEM-FOUR')
   itemFour;
-
-  String toJson() => _$EnumNameStringEnumMap[this]!;
 }
-
-const _$EnumNameStringEnumMap = {
-  EnumNameString.itemOne: 'itemOne',
-  EnumNameString.itemTwo: 'ItemTwo',
-  EnumNameString.itemThree: 'item_three',
-  EnumNameString.itemFour: 'ITEM-FOUR',
-};
 ''';
-      const expectedContent2 = r'''
+      const expectedContent2 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1121,18 +1104,10 @@ enum KeywordsName {
   valueFor,
   @JsonValue('do')
   valueDo;
-
-  String toJson() => _$KeywordsNameEnumMap[this]!;
 }
-
-const _$KeywordsNameEnumMap = {
-  KeywordsName.valueFalse: 'FALSE',
-  KeywordsName.valueFor: 'for',
-  KeywordsName.valueDo: 'do',
-};
 ''';
 
-      const expectedContent3 = r'''
+      const expectedContent3 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1145,16 +1120,7 @@ enum EnumNameStringWithLeadingNumbers {
   value3itemThree,
   @JsonValue('4ITEM-FOUR')
   value4itemFour;
-
-  String toJson() => _$EnumNameStringWithLeadingNumbersEnumMap[this]!;
 }
-
-const _$EnumNameStringWithLeadingNumbersEnumMap = {
-  EnumNameStringWithLeadingNumbers.value1itemOne: '1itemOne',
-  EnumNameStringWithLeadingNumbers.value2ItemTwo: '2ItemTwo',
-  EnumNameStringWithLeadingNumbers.value3itemThree: '3item_three',
-  EnumNameStringWithLeadingNumbers.value4itemFour: '4ITEM-FOUR',
-};
 ''';
 
       expect(files[0].contents, expectedContent0);
@@ -1186,7 +1152,7 @@ const _$EnumNameStringWithLeadingNumbersEnumMap = {
       for (final enumClass in dataClasses) {
         files.add(fillController.fillDtoContent(enumClass));
       }
-      const expectedContent0 = r'''
+      const expectedContent0 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1197,18 +1163,10 @@ enum EnumName {
   value2,
   @JsonValue(3)
   value3;
-
-  int toJson() => _$EnumNameEnumMap[this]!;
 }
-
-const _$EnumNameEnumMap = {
-  EnumName.value1: 1,
-  EnumName.value2: 2,
-  EnumName.value3: 3,
-};
 ''';
 
-      const expectedContent1 = r'''
+      const expectedContent1 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1221,18 +1179,9 @@ enum EnumNameString {
   itemThree,
   @JsonValue('ITEM-FOUR')
   itemFour;
-
-  String toJson() => _$EnumNameStringEnumMap[this]!;
 }
-
-const _$EnumNameStringEnumMap = {
-  EnumNameString.itemOne: 'itemOne',
-  EnumNameString.itemTwo: 'ItemTwo',
-  EnumNameString.itemThree: 'item_three',
-  EnumNameString.itemFour: 'ITEM-FOUR',
-};
 ''';
-      const expectedContent2 = r'''
+      const expectedContent2 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1243,15 +1192,7 @@ enum KeywordsName {
   valueFor,
   @JsonValue('do')
   valueDo;
-
-  String toJson() => _$KeywordsNameEnumMap[this]!;
 }
-
-const _$KeywordsNameEnumMap = {
-  KeywordsName.valueFalse: 'FALSE',
-  KeywordsName.valueFor: 'for',
-  KeywordsName.valueDo: 'do',
-};
 ''';
       expect(files[0].contents, expectedContent0);
       expect(files[1].contents, expectedContent1);


### PR DESCRIPTION
Updated `retrofit_generator` dependency to [7.0.7](https://github.com/trevorwang/retrofit.dart/releases/tag/7.0.7) and consequently removed unused `.toJson()` generated methods in enums