### PR TITLE
Feat/optional to json enums

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.2.1
+- Updated `retrofit_generator` dependency to [7.0.8](https://github.com/trevorwang/retrofit.dart/releases/tag/7.0.8) and added config option to generate `.toJson()` methods in enums (`retrofit_generator` will use `.toJson()` instead of `.name` in this case)
+
 ## 1.2.0
 - Updated `retrofit_generator` dependency to [7.0.7](https://github.com/trevorwang/retrofit.dart/releases/tag/7.0.7) and consequently removed unused `.toJson()` generated methods in enums
 

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -56,6 +56,7 @@ swagger_parser:
   replacement_rules: # Optional. Set regex replacement rules for the names of the generated classes/enums. All rules are applied in order.
     - pattern: "[0-9]+"
       replacement: ""
+  include_to_json_in_enums: false # Optional. Set 'true' to include toJson() in enums. If set to false, serialization will use .name instead. Default: false
 ```
 
 

--- a/swagger_parser/example/pubspec.yaml
+++ b/swagger_parser/example/pubspec.yaml
@@ -15,11 +15,12 @@ dev_dependencies:
   carapacik_lints: ^1.4.0
   freezed: ^2.3.5
   json_serializable: ^6.7.0
-  retrofit_generator: ^7.0.7
+  retrofit_generator: ^7.0.8
   swagger_parser:
     path:
       ../
 
 swagger_parser:
-  schema_path: assets/openapi.json
+  schema_path: assets/restapi.json
   output_directory: lib/api
+  include_to_json_in_enums: true

--- a/swagger_parser/example/pubspec.yaml
+++ b/swagger_parser/example/pubspec.yaml
@@ -21,6 +21,5 @@ dev_dependencies:
       ../
 
 swagger_parser:
-  schema_path: assets/restapi.json
+  schema_path: assets/openapi.json
   output_directory: lib/api
-  include_to_json_in_enums: true

--- a/swagger_parser/lib/src/config/yaml_config.dart
+++ b/swagger_parser/lib/src/config/yaml_config.dart
@@ -92,6 +92,13 @@ class YamlConfig {
       _freezed = yamlConfig['freezed'] as bool?;
     }
 
+    if (yamlConfig.containsKey('include_to_json_in_enums')) {
+      if (yamlConfig['include_to_json_in_enums'] is! bool?) {
+        throw const ConfigException("Config parameter 'include_to_json_in_enums' must be bool.");
+      }
+      _includeToJsonInEnums = yamlConfig['include_to_json_in_enums'] as bool?;
+    }
+
     if (yamlConfig.containsKey('replacement_rules')) {
       if (yamlConfig['replacement_rules'] is! YamlList) {
         throw const ConfigException(
@@ -129,6 +136,8 @@ class YamlConfig {
   bool? _rootInterface;
   bool? _squishClients;
   bool? _freezed;
+  bool? _includeToJsonInEnums;
+
   final List<ReplacementRule> _replacementRules = [];
 
   String get outputDirectory => _outputDirectory!;
@@ -146,4 +155,6 @@ class YamlConfig {
   bool? get freezed => _freezed;
 
   List<ReplacementRule> get replacementRules => _replacementRules;
+
+  bool? get includeToJsonInEnums => _includeToJsonInEnums;
 }

--- a/swagger_parser/lib/src/config/yaml_config.dart
+++ b/swagger_parser/lib/src/config/yaml_config.dart
@@ -94,7 +94,8 @@ class YamlConfig {
 
     if (yamlConfig.containsKey('include_to_json_in_enums')) {
       if (yamlConfig['include_to_json_in_enums'] is! bool?) {
-        throw const ConfigException("Config parameter 'include_to_json_in_enums' must be bool.");
+        throw const ConfigException(
+            "Config parameter 'include_to_json_in_enums' must be bool.");
       }
       _includeToJsonInEnums = yamlConfig['include_to_json_in_enums'] as bool?;
     }

--- a/swagger_parser/lib/src/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/fill_controller.dart
@@ -11,23 +11,30 @@ class FillController {
     String clientPostfix = 'Client',
     bool squishClients = false,
     bool freezed = false,
-  })  : _clientPostfix = clientPostfix,
+    bool includeToJsonInEnums = false,
+  })
+      : _clientPostfix = clientPostfix,
         _programmingLanguage = programmingLanguage,
         _squishClients = squishClients,
-        _freezed = freezed;
+        _freezed = freezed,
+        _includeToJsonInEnums = includeToJsonInEnums;
 
   final ProgrammingLanguage _programmingLanguage;
   final String _clientPostfix;
   final bool _freezed;
   final bool _squishClients;
+  final bool _includeToJsonInEnums;
 
   /// Return [GeneratedFile] generated from given [UniversalDataClass]
-  GeneratedFile fillDtoContent(UniversalDataClass dataClass) => GeneratedFile(
+  GeneratedFile fillDtoContent(UniversalDataClass dataClass) =>
+      GeneratedFile(
         name: 'shared_models/'
-            '${_programmingLanguage == ProgrammingLanguage.dart ? dataClass.name.toSnake : dataClass.name.toPascal}'
+            '${_programmingLanguage == ProgrammingLanguage.dart ? dataClass.name
+            .toSnake : dataClass.name.toPascal}'
             '.${_programmingLanguage.fileExtension}',
         contents:
-            _programmingLanguage.dtoFileContent(dataClass, freezed: _freezed),
+        _programmingLanguage.dtoFileContent(dataClass, freezed: _freezed,
+            includeToJsonInEnums: _includeToJsonInEnums),
       );
 
   /// Return [GeneratedFile] generated from given [UniversalRestClient]

--- a/swagger_parser/lib/src/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/fill_controller.dart
@@ -12,8 +12,7 @@ class FillController {
     bool squishClients = false,
     bool freezed = false,
     bool includeToJsonInEnums = false,
-  })
-      : _clientPostfix = clientPostfix,
+  })  : _clientPostfix = clientPostfix,
         _programmingLanguage = programmingLanguage,
         _squishClients = squishClients,
         _freezed = freezed,
@@ -26,15 +25,12 @@ class FillController {
   final bool _includeToJsonInEnums;
 
   /// Return [GeneratedFile] generated from given [UniversalDataClass]
-  GeneratedFile fillDtoContent(UniversalDataClass dataClass) =>
-      GeneratedFile(
+  GeneratedFile fillDtoContent(UniversalDataClass dataClass) => GeneratedFile(
         name: 'shared_models/'
-            '${_programmingLanguage == ProgrammingLanguage.dart ? dataClass.name
-            .toSnake : dataClass.name.toPascal}'
+            '${_programmingLanguage == ProgrammingLanguage.dart ? dataClass.name.toSnake : dataClass.name.toPascal}'
             '.${_programmingLanguage.fileExtension}',
-        contents:
-        _programmingLanguage.dtoFileContent(dataClass, freezed: _freezed,
-            includeToJsonInEnums: _includeToJsonInEnums),
+        contents: _programmingLanguage.dtoFileContent(dataClass,
+            freezed: _freezed, includeToJsonInEnums: _includeToJsonInEnums),
       );
 
   /// Return [GeneratedFile] generated from given [UniversalRestClient]

--- a/swagger_parser/lib/src/generator/generator.dart
+++ b/swagger_parser/lib/src/generator/generator.dart
@@ -55,6 +55,10 @@ class Generator {
       _clientPostfix = yamlConfig.clientPostfix!;
     }
 
+    if (yamlConfig.includeToJsonInEnums != null) {
+      _includeToJsonInEnums = yamlConfig.includeToJsonInEnums!;
+    }
+
     _replacementRules = yamlConfig.replacementRules;
   }
 
@@ -90,6 +94,9 @@ class Generator {
 
   /// Client postfix
   String _clientPostfix = 'Client';
+
+  /// If true, generated enums will have toJson method
+  bool _includeToJsonInEnums = false;
 
   /// List of rules used to replace patterns in generated class names
   List<ReplacementRule> _replacementRules = [];
@@ -149,6 +156,7 @@ class Generator {
       clientPostfix: _clientPostfix,
       freezed: _freezed,
       squishClients: _squishClients,
+      includeToJsonInEnums: _includeToJsonInEnums,
     );
     final files = <GeneratedFile>[];
     for (final client in _restClients) {

--- a/swagger_parser/lib/src/generator/models/programming_lang.dart
+++ b/swagger_parser/lib/src/generator/models/programming_lang.dart
@@ -34,7 +34,8 @@ enum ProgrammingLanguage {
       ProgrammingLanguage.values.firstWhereOrNull((e) => e.name == value);
 
   /// Determines template for generating DTOs by language
-  String dtoFileContent(UniversalDataClass dataClass, {bool freezed = false, bool includeToJsonInEnums = false}) {
+  String dtoFileContent(UniversalDataClass dataClass,
+      {bool freezed = false, bool includeToJsonInEnums = false}) {
     switch (this) {
       case ProgrammingLanguage.dart:
         if (dataClass is UniversalEnumClass) {

--- a/swagger_parser/lib/src/generator/models/programming_lang.dart
+++ b/swagger_parser/lib/src/generator/models/programming_lang.dart
@@ -34,13 +34,14 @@ enum ProgrammingLanguage {
       ProgrammingLanguage.values.firstWhereOrNull((e) => e.name == value);
 
   /// Determines template for generating DTOs by language
-  String dtoFileContent(UniversalDataClass dataClass, {bool freezed = false}) {
+  String dtoFileContent(UniversalDataClass dataClass, {bool freezed = false, bool includeToJsonInEnums = false}) {
     switch (this) {
       case ProgrammingLanguage.dart:
         if (dataClass is UniversalEnumClass) {
           return dartEnumDtoTemplate(
             dataClass,
             freezed: freezed,
+            includeToJsonInEnums: includeToJsonInEnums,
           );
         } else if (dataClass is UniversalComponentClass) {
           if (dataClass.typeDef) {

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -7,6 +7,7 @@ import '../models/universal_enum_class.dart';
 String dartEnumDtoTemplate(
   UniversalEnumClass enumClass, {
   bool freezed = false,
+  bool includeToJsonInEnums = false,
 }) {
   final className = enumClass.name.toPascal;
   return '''
@@ -15,10 +16,22 @@ import '${freezed ? 'package:freezed_annotation/freezed_annotation.dart' : 'pack
 ${descriptionComment(enumClass.description)}@JsonEnum()
 enum $className {
 ${enumClass.items.map((e) => _jsonValue(enumClass.type, e)).join(',\n')};
-}
+${includeToJsonInEnums ? _toJson(enumClass, className) : '}'}
 ''';
 }
 
 String _jsonValue(String type, String item) => '''
   @JsonValue(${type == 'string' ? "'$item'" : item})
   ${prefixForEnumItems(type, item)}''';
+
+String _toJson(UniversalEnumClass enumClass, String className) => '''
+  ${enumClass.type.toDartType()} toJson() => _\$${className}EnumMap[this]!;
+}  
+
+const _\$${className}EnumMap = {
+  ${enumClass.items.map(
+      (e) => '$className.${prefixForEnumItems(enumClass.type, e)}: '
+      '${enumClass.type.quoterForStringType()}$e${enumClass.type.quoterForStringType()}',
+).join(',\n  ')},
+};
+''';

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -25,13 +25,13 @@ String _jsonValue(String type, String item) => '''
   ${prefixForEnumItems(type, item)}''';
 
 String _toJson(UniversalEnumClass enumClass, String className) => '''
+
   ${enumClass.type.toDartType()} toJson() => _\$${className}EnumMap[this]!;
-}  
+}
 
 const _\$${className}EnumMap = {
   ${enumClass.items.map(
           (e) => '$className.${prefixForEnumItems(enumClass.type, e)}: '
               '${enumClass.type.quoterForStringType()}$e${enumClass.type.quoterForStringType()}',
         ).join(',\n  ')},
-};
-''';
+};''';

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -30,8 +30,8 @@ String _toJson(UniversalEnumClass enumClass, String className) => '''
 
 const _\$${className}EnumMap = {
   ${enumClass.items.map(
-      (e) => '$className.${prefixForEnumItems(enumClass.type, e)}: '
-      '${enumClass.type.quoterForStringType()}$e${enumClass.type.quoterForStringType()}',
-).join(',\n  ')},
+          (e) => '$className.${prefixForEnumItems(enumClass.type, e)}: '
+              '${enumClass.type.quoterForStringType()}$e${enumClass.type.quoterForStringType()}',
+        ).join(',\n  ')},
 };
 ''';

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 homepage: https://omega-r.com
 topics:

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1035,36 +1035,37 @@ class ClassName with _$ClassName {
   });
 
   group('Enum', () {
-    test('dart + json_serializable', () async {
-      const dataClasses = [
-        UniversalEnumClass(
-          name: 'EnumName',
-          type: 'int',
-          items: {'1', '2', '3'},
-        ),
-        UniversalEnumClass(
-          name: 'EnumNameString',
-          type: 'string',
-          items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
-        ),
-        UniversalEnumClass(
-          name: 'KeywordsName',
-          type: 'string',
-          items: {'FALSE', 'for', 'do'},
-        ),
-        UniversalEnumClass(
-          name: 'EnumNameStringWithLeadingNumbers',
-          type: 'string',
-          items: {'1itemOne', '2ItemTwo', '3item_three', '4ITEM-FOUR'},
-        ),
-      ];
+    group('dart + json_serializable', () {
+      test('without toJson()', () async {
+        const dataClasses = [
+          UniversalEnumClass(
+            name: 'EnumName',
+            type: 'int',
+            items: {'1', '2', '3'},
+          ),
+          UniversalEnumClass(
+            name: 'EnumNameString',
+            type: 'string',
+            items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
+          ),
+          UniversalEnumClass(
+            name: 'KeywordsName',
+            type: 'string',
+            items: {'FALSE', 'for', 'do'},
+          ),
+          UniversalEnumClass(
+            name: 'EnumNameStringWithLeadingNumbers',
+            type: 'string',
+            items: {'1itemOne', '2ItemTwo', '3item_three', '4ITEM-FOUR'},
+          ),
+        ];
 
-      const fillController = FillController();
-      final files = <GeneratedFile>[];
-      for (final enumClass in dataClasses) {
-        files.add(fillController.fillDtoContent(enumClass));
-      }
-      const expectedContent0 = '''
+        const fillController = FillController();
+        final files = <GeneratedFile>[];
+        for (final enumClass in dataClasses) {
+          files.add(fillController.fillDtoContent(enumClass));
+        }
+        const expectedContent0 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1078,7 +1079,7 @@ enum EnumName {
 }
 ''';
 
-      const expectedContent1 = '''
+        const expectedContent1 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1093,7 +1094,7 @@ enum EnumNameString {
   itemFour;
 }
 ''';
-      const expectedContent2 = '''
+        const expectedContent2 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1107,7 +1108,7 @@ enum KeywordsName {
 }
 ''';
 
-      const expectedContent3 = '''
+        const expectedContent3 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
@@ -1123,36 +1124,108 @@ enum EnumNameStringWithLeadingNumbers {
 }
 ''';
 
-      expect(files[0].contents, expectedContent0);
-      expect(files[1].contents, expectedContent1);
-      expect(files[2].contents, expectedContent2);
-      expect(files[3].contents, expectedContent3);
+        expect(files[0].contents, expectedContent0);
+        expect(files[1].contents, expectedContent1);
+        expect(files[2].contents, expectedContent2);
+        expect(files[3].contents, expectedContent3);
+      });
+
+      test('with toJson() in enums', () async {
+        const dataClasses = [
+          UniversalEnumClass(
+            name: 'EnumName',
+            type: 'int',
+            items: {'1', '2', '3'},
+          ),
+          UniversalEnumClass(
+            name: 'EnumNameString',
+            type: 'string',
+            items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
+          ),
+        ];
+
+        const fillController = FillController(includeToJsonInEnums: true);
+        final files = <GeneratedFile>[];
+        for (final enumClass in dataClasses) {
+          files.add(fillController.fillDtoContent(enumClass));
+        }
+        const expectedContent0 = r'''
+import 'package:json_annotation/json_annotation.dart';
+
+@JsonEnum()
+enum EnumName {
+  @JsonValue(1)
+  value1,
+  @JsonValue(2)
+  value2,
+  @JsonValue(3)
+  value3;
+
+  int toJson() => _$EnumNameEnumMap[this]!;
+}
+
+const _$EnumNameEnumMap = {
+  EnumName.value1: 1,
+  EnumName.value2: 2,
+  EnumName.value3: 3,
+};
+''';
+
+        const expectedContent1 = r'''
+import 'package:json_annotation/json_annotation.dart';
+
+@JsonEnum()
+enum EnumNameString {
+  @JsonValue('itemOne')
+  itemOne,
+  @JsonValue('ItemTwo')
+  itemTwo,
+  @JsonValue('item_three')
+  itemThree,
+  @JsonValue('ITEM-FOUR')
+  itemFour;
+
+  String toJson() => _$EnumNameStringEnumMap[this]!;
+}
+
+const _$EnumNameStringEnumMap = {
+  EnumNameString.itemOne: 'itemOne',
+  EnumNameString.itemTwo: 'ItemTwo',
+  EnumNameString.itemThree: 'item_three',
+  EnumNameString.itemFour: 'ITEM-FOUR',
+};
+''';
+
+        expect(files[0].contents, expectedContent0);
+        expect(files[1].contents, expectedContent1);
+      });
     });
 
-    test('dart + freezed', () async {
-      const dataClasses = [
-        UniversalEnumClass(
-          name: 'EnumName',
-          type: 'int',
-          items: {'1', '2', '3'},
-        ),
-        UniversalEnumClass(
-          name: 'EnumNameString',
-          type: 'string',
-          items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
-        ),
-        UniversalEnumClass(
-          name: 'KeywordsName',
-          type: 'string',
-          items: {'FALSE', 'for', 'do'},
-        ),
-      ];
-      const fillController = FillController(freezed: true);
-      final files = <GeneratedFile>[];
-      for (final enumClass in dataClasses) {
-        files.add(fillController.fillDtoContent(enumClass));
-      }
-      const expectedContent0 = '''
+    group('dart + freezed', () {
+      test('without toJson()', () async {
+        const dataClasses = [
+          UniversalEnumClass(
+            name: 'EnumName',
+            type: 'int',
+            items: {'1', '2', '3'},
+          ),
+          UniversalEnumClass(
+            name: 'EnumNameString',
+            type: 'string',
+            items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
+          ),
+          UniversalEnumClass(
+            name: 'KeywordsName',
+            type: 'string',
+            items: {'FALSE', 'for', 'do'},
+          ),
+        ];
+        const fillController = FillController(freezed: true);
+        final files = <GeneratedFile>[];
+        for (final enumClass in dataClasses) {
+          files.add(fillController.fillDtoContent(enumClass));
+        }
+        const expectedContent0 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1166,7 +1239,7 @@ enum EnumName {
 }
 ''';
 
-      const expectedContent1 = '''
+        const expectedContent1 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1181,7 +1254,7 @@ enum EnumNameString {
   itemFour;
 }
 ''';
-      const expectedContent2 = '''
+        const expectedContent2 = '''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
@@ -1194,9 +1267,80 @@ enum KeywordsName {
   valueDo;
 }
 ''';
-      expect(files[0].contents, expectedContent0);
-      expect(files[1].contents, expectedContent1);
-      expect(files[2].contents, expectedContent2);
+        expect(files[0].contents, expectedContent0);
+        expect(files[1].contents, expectedContent1);
+        expect(files[2].contents, expectedContent2);
+      });
+
+
+      test('with toJson()', () async {
+        const dataClasses = [
+          UniversalEnumClass(
+            name: 'EnumName',
+            type: 'int',
+            items: {'1', '2', '3'},
+          ),
+          UniversalEnumClass(
+            name: 'EnumNameString',
+            type: 'string',
+            items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
+          ),
+        ];
+        const fillController = FillController(freezed: true, includeToJsonInEnums: true);
+        final files = <GeneratedFile>[];
+        for (final enumClass in dataClasses) {
+          files.add(fillController.fillDtoContent(enumClass));
+        }
+
+        const expectedContent0 = r'''
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum EnumName {
+  @JsonValue(1)
+  value1,
+  @JsonValue(2)
+  value2,
+  @JsonValue(3)
+  value3;
+
+  int toJson() => _$EnumNameEnumMap[this]!;
+}
+
+const _$EnumNameEnumMap = {
+  EnumName.value1: 1,
+  EnumName.value2: 2,
+  EnumName.value3: 3,
+};
+''';
+
+        const expectedContent1 = r'''
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum EnumNameString {
+  @JsonValue('itemOne')
+  itemOne,
+  @JsonValue('ItemTwo')
+  itemTwo,
+  @JsonValue('item_three')
+  itemThree,
+  @JsonValue('ITEM-FOUR')
+  itemFour;
+
+  String toJson() => _$EnumNameStringEnumMap[this]!;
+}
+
+const _$EnumNameStringEnumMap = {
+  EnumNameString.itemOne: 'itemOne',
+  EnumNameString.itemTwo: 'ItemTwo',
+  EnumNameString.itemThree: 'item_three',
+  EnumNameString.itemFour: 'ITEM-FOUR',
+};
+''';
+        expect(files[0].contents, expectedContent0);
+        expect(files[1].contents, expectedContent1);
+      });
     });
 
     test('kotlin + moshi', () async {

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1272,7 +1272,6 @@ enum KeywordsName {
         expect(files[2].contents, expectedContent2);
       });
 
-
       test('with toJson()', () async {
         const dataClasses = [
           UniversalEnumClass(
@@ -1286,7 +1285,8 @@ enum KeywordsName {
             items: {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
           ),
         ];
-        const fillController = FillController(freezed: true, includeToJsonInEnums: true);
+        const fillController =
+            FillController(freezed: true, includeToJsonInEnums: true);
         final files = <GeneratedFile>[];
         for (final enumClass in dataClasses) {
           files.add(fillController.fillDtoContent(enumClass));


### PR DESCRIPTION
Added possibility to generate `.toJson()` adding `include_to_json_in_enums: true` in `pubspec.yaml`. This is done to support `retrofit_generator` 7.0.8 (which uses `.toJson()` to serialize enums if exist, otherwise `.name`)