### PR TITLE
fix: fixes negative number values in integer enums

### DIFF
--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -79,7 +79,8 @@ String prefixForEnumItems(String type, String item, {bool dart = true}) {
           dartKeywords.contains(item.toCamel) ||
           startsWithNumber.hasMatch(item)
       ? dart
-          ? 'value ${item.toCamel}'.toCamel
+          ? 'value ${item.startsWith('-') ? 'Minus' : ''} ${item.toCamel}'
+              .toCamel
           : 'value ${item.toSnake}'.toSnake.toUpperCase()
       : dart
           ? item.toCamel


### PR DESCRIPTION
Hey @Carapacik and thanks for a great package!

In this super small patch PR, I'm trying to fix duplicate field names in integer-based enums (provided by Open-API definition JSON). For example, if we have a model defined like this:
```json
"Foo": { "enum": [ -1, 0, 1, 2 ], "type": "number" },
```
The package will code generate a model like this:
```dart
@JsonEnum()
enum Foo {
  @JsonValue(-1)
  value1, // <--- Error, duplicated field.
  @JsonValue(0)
  value0,
  @JsonValue(1)
  value1, // <--- Error, duplicated field.
  @JsonValue(2)
  value2;

  num toJson() => _$FooEnumMap[this]!;
}
```

And in this PR package will generate a proper model like this:

```dart
@JsonEnum()
enum Foo {
  @JsonValue(-1)
  valueMinus1, // <--- Yey! No errors here.
  @JsonValue(0)
  value0,
  @JsonValue(1)
  value1, // <--- And no errors here.
  @JsonValue(2)
  value2;

  num toJson() => _$FooEnumMap[this]!;
}
```

Because of modifications in the code generation part on the Dart side that will remove "-" from the value name. Thanks one more time!