### PR TITLE
Fix groupping words for acronyms and abbreviations

### DIFF
--- a/swagger_parser/lib/src/utils/case_utils.dart
+++ b/swagger_parser/lib/src/utils/case_utils.dart
@@ -9,6 +9,8 @@ class CaseUtils {
   static const _separateSymbolsList = r' #,-./@\_{}';
   static const _upperRegex = r'[A-Z]$';
 
+  final _upperCaseTwoLetterWords = <String>{};
+
   List<String> _groupIntoWords(String text) {
     final sb = StringBuffer();
     final words = <String>[];
@@ -17,15 +19,29 @@ class CaseUtils {
     for (var i = 0; i < text.length; i++) {
       final char = text[i];
       final nextChar = i + 1 == text.length ? null : text[i + 1];
+      final nextNextChar = i + 2 >= text.length ? null : text[i + 2];
+
       if (_separateSymbolsList.contains(char)) {
         continue;
       }
+
       sb.write(char);
+      final upperRegex = RegExp(_upperRegex);
+
       final isEndOfWord = nextChar == null ||
-          (RegExp(_upperRegex).hasMatch(nextChar) && !isAllCaps) ||
+          (upperRegex.hasMatch(nextChar) &&
+              !isAllCaps &&
+              (!upperRegex.hasMatch(char) ||
+                  (nextNextChar != null &&
+                      !upperRegex.hasMatch(nextNextChar)))) ||
           _separateSymbolsList.contains(nextChar);
+
       if (isEndOfWord) {
-        words.add(sb.toString());
+        final word = '$sb';
+        if (sb.length == 2 && word.toUpperCase() == word) {
+          _upperCaseTwoLetterWords.add(word);
+        }
+        words.add(word);
         sb.clear();
       }
     }
@@ -48,11 +64,19 @@ class CaseUtils {
   /// Return text formatted to snake case
   String get snakeCase => _words.map((word) => word.toLowerCase()).join('_');
 
-  /// Return text formatted to snake case
+  /// Return text formatted to screaming snake case
   String get screamingSnakeCase => snakeCase.toUpperCase();
 
-  String _upperCaseFirstLetter(String word) =>
-      '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+  String _upperCaseFirstLetter(String word) {
+    if (word.length == 2) {
+      final upperCase = word.toUpperCase();
+      if (_upperCaseTwoLetterWords.contains(upperCase)) {
+        return upperCase;
+      }
+    }
+
+    return '${word.substring(0, 1).toUpperCase()}${word.substring(1).toLowerCase()}';
+  }
 }
 
 extension StringToCaseX on String {

--- a/swagger_parser/lib/src/utils/case_utils.dart
+++ b/swagger_parser/lib/src/utils/case_utils.dart
@@ -7,9 +7,8 @@ class CaseUtils {
 
   late final List<String> _words;
   static const _separateSymbolsList = r' #,-./@\_{}';
-  static const _upperRegex = r'[A-Z]$';
-
-  final _upperCaseTwoLetterWords = <String>{};
+  final _upperCaseRegex = RegExp('[A-Z]');
+  final _upperCaseTwoLettersRowWords = <String>{};
 
   List<String> _groupIntoWords(String text) {
     final sb = StringBuffer();
@@ -18,28 +17,27 @@ class CaseUtils {
 
     for (var i = 0; i < text.length; i++) {
       final char = text[i];
-      final nextChar = i + 1 == text.length ? null : text[i + 1];
-      final nextNextChar = i + 2 >= text.length ? null : text[i + 2];
-
       if (_separateSymbolsList.contains(char)) {
         continue;
       }
 
+      final nextChar = i + 1 == text.length ? null : text[i + 1];
+      final nextSecondChar = i + 2 >= text.length ? null : text[i + 2];
+
       sb.write(char);
-      final upperRegex = RegExp(_upperRegex);
 
       final isEndOfWord = nextChar == null ||
-          (upperRegex.hasMatch(nextChar) &&
+          (_upperCaseRegex.hasMatch(nextChar) &&
               !isAllCaps &&
-              (!upperRegex.hasMatch(char) ||
-                  (nextNextChar != null &&
-                      !upperRegex.hasMatch(nextNextChar)))) ||
+              (!_upperCaseRegex.hasMatch(char) ||
+                  (nextSecondChar != null &&
+                      !_upperCaseRegex.hasMatch(nextSecondChar)))) ||
           _separateSymbolsList.contains(nextChar);
 
       if (isEndOfWord) {
-        final word = '$sb';
+        final word = sb.toString();
         if (sb.length == 2 && word.toUpperCase() == word) {
-          _upperCaseTwoLetterWords.add(word);
+          _upperCaseTwoLettersRowWords.add(word);
         }
         words.add(word);
         sb.clear();
@@ -70,7 +68,7 @@ class CaseUtils {
   String _upperCaseFirstLetter(String word) {
     if (word.length == 2) {
       final upperCase = word.toUpperCase();
-      if (_upperCaseTwoLetterWords.contains(upperCase)) {
+      if (_upperCaseTwoLettersRowWords.contains(upperCase)) {
         return upperCase;
       }
     }


### PR DESCRIPTION
To match effective dart: DO capitalize acronyms and abbreviations longer than two letters like words.

https://dart.dev/effective-dart/style#do-capitalize-acronyms-and-abbreviations-longer-than-two-letters-like-words

Example:
```json
{
  "openapi": "3.1.0",
  "components": {
    "schemas": {
      "HTTPValidationError": {
        "type": "object",
        "title": "HTTPValidationError"
      },
      "DeviceFromDB": {
        "type": "object",
        "title": "DeviceFromDB"
      },
      "IOPort": {
        "type": "object",
        "title": "IOPort"
      },
      "HrvSampleRMSSD": {
        "type": "object",
        "title": "HrvSampleRMSSD"
      },
      "HrvSampleSDNNFromDB": {
        "type": "object",
        "title": "HrvSampleSDNNFromDB"
      }
    }
  }
}
```
Before:
![image](https://github.com/Carapacik/swagger_parser/assets/34741787/5da9298d-6bb2-4331-beb3-53267349a969) 
![image](https://github.com/Carapacik/swagger_parser/assets/34741787/b1c18c6d-bad1-4347-90e1-58419af593ce)


After (recommended by effective dart):
![image](https://github.com/Carapacik/swagger_parser/assets/34741787/26d9975a-ad9e-49f4-a4ab-a8ef15d9f0a3) 
![image](https://github.com/Carapacik/swagger_parser/assets/34741787/0c097463-6bd4-4ffb-92d1-4995ff83a697)

