### PR TITLE
Fixes for replacement rules and case utils

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.2
+- Fix groupping words for abbreviations when special characters are present
+- Fix replacement type for enum classes
+- Takes case in replacement
+
 ## 1.6.1
 - Add summary of the methods to the code docs
 - Fix indents for multiline code docs

--- a/swagger_parser/lib/src/generator/models/replacement_rule.dart
+++ b/swagger_parser/lib/src/generator/models/replacement_rule.dart
@@ -1,3 +1,5 @@
+import '../../utils/case_utils.dart';
+
 /// Used to store regex patterns for replacing names during generation
 final class ReplacementRule {
   /// Constructor for [ReplacementRule]
@@ -12,6 +14,16 @@ final class ReplacementRule {
   /// Replacement string
   final String replacement;
 
+  /// Returns the replacement string in the correct case
+  String get replacementInCorrectCase => replacement.isNotEmpty
+      ? replacement[0] == replacement[0].toUpperCase()
+          ? replacement.toPascal
+          : replacement.toCamel
+      : replacement;
+
   /// Applies the replacement rule to the given input string
-  String? apply(String? input) => input?.replaceAll(pattern, replacement);
+  String? apply(String? input) => input?.replaceAll(
+        pattern,
+        replacementInCorrectCase,
+      );
 }

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -529,10 +529,9 @@ class OpenApiParser {
       } else if (value.containsKey(_enumConst)) {
         final items =
             (value[_enumConst] as List).map((e) => e.toString()).toSet();
-        var type = value[_typeConst].toString();
+        final type = value[_typeConst].toString();
         for (final replacementRule in _replacementRules) {
           key = replacementRule.apply(key)!;
-          type = replacementRule.apply(type)!;
         }
 
         dataClasses.add(

--- a/swagger_parser/lib/src/utils/case_utils.dart
+++ b/swagger_parser/lib/src/utils/case_utils.dart
@@ -7,7 +7,8 @@ class CaseUtils {
 
   late final List<String> _words;
   static const _separateSymbolsList = r' #,-./@\_{}';
-  final _upperCaseRegex = RegExp('[A-Z]');
+  static final _upperCaseRegex = RegExp('[A-Z]');
+  static final _lowerCaseRegex = RegExp('[a-z]');
   final _upperCaseTwoLettersRowWords = <String>{};
 
   List<String> _groupIntoWords(String text) {
@@ -31,7 +32,7 @@ class CaseUtils {
               !isAllCaps &&
               (!_upperCaseRegex.hasMatch(char) ||
                   (nextSecondChar != null &&
-                      !_upperCaseRegex.hasMatch(nextSecondChar)))) ||
+                      _lowerCaseRegex.hasMatch(nextSecondChar)))) ||
           _separateSymbolsList.contains(nextChar);
 
       if (isEndOfWord) {

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.6.1
+version: 1.6.2
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 homepage: https://omega-r.com
 topics:


### PR DESCRIPTION
#### Fix groupping words for abbreviations when special characters are present

```json
"$ref": "#/components/schemas/HrvSampleRMSSD-Input"
```
Before:
`hrv_sample_rmss_d_input_dto.dart`
```dart
class HrvSampleRmssDInput
```

After:
`hrv_sample_rmssd_input.dart`
```dart
class HrvSampleRmssdInput
```
#### Fix replacement type for enum classes

```yaml
  enums_to_json: true
  replacement_rules:
    - pattern: "$"
      replacement: "DTO"
```

Before:
```dart
@JsonEnum()
enum UploadTypeDto {
  @JsonValue(0)
  value0,
  @JsonValue(1)
  value1;

  integerDTO toJson() => _$UploadTypeDtoEnumMap[this]!;    // <-- error
}
```


After:
```dart
@JsonEnum()
enum UploadTypeDto {
  @JsonValue(0)
  value0,
  @JsonValue(1)
  value1;

  int toJson() => _$UploadTypeDtoEnumMap[this]!;
}
```

#### Takes case in replacement

```yaml
  enums_to_json: true
  replacement_rules:
    - pattern: "$"
      replacement: "DTO"
```

Before:
```dart
@JsonSerializable()
class HttpValidationErrorDto {
  const HttpValidationErrorDto({
    this.detail,
  });
  
  factory HttpValidationErrorDto.fromJson(Map<String, Object?> json) => _$HttpValidationErrorDtoFromJson(json);
  
  final List<ValidationErrorDTO>? detail;     // <-- error, should be List<ValidationErrorDto>?

  Map<String, Object?> toJson() => _$HttpValidationErrorDtoToJson(this);
}
```
After:
```dart
@JsonSerializable()
class HttpValidationErrorDto {
  const HttpValidationErrorDto({
    this.detail,
  });
  
  factory HttpValidationErrorDto.fromJson(Map<String, Object?> json) => _$HttpValidationErrorDtoFromJson(json);
  
  final List<ValidationErrorDto>? detail;

  Map<String, Object?> toJson() => _$HttpValidationErrorDtoToJson(this);
}
```