### PR TITLE
Support of default values for ref enum types

### DIFF
--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -830,6 +830,7 @@ class OpenApiParser {
           type = replacementRule.apply(type)!;
         }
       }
+
       return (
         type: UniversalType(
           type: type,
@@ -839,6 +840,7 @@ class OpenApiParser {
           format: map[_formatConst]?.toString(),
           jsonKey: name,
           defaultValue: map[_defaultConst]?.toString(),
+          enumType: map[_defaultConst] != null && import != null ? type : null,
           isRequired: isRequired,
           nullable: root &&
               map.containsKey(_nullableConst) &&

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -74,14 +74,15 @@ extension StringTypeX on String {
 }
 
 String prefixForEnumItems(String type, String item, {bool dart = true}) {
-  final startsWithNumber = RegExp(r'^\d');
-  return type != 'string' ||
-          dartKeywords.contains(item.toCamel) ||
-          startsWithNumber.hasMatch(item)
+  final startsWithNumber = RegExp(r'^\d').hasMatch(item);
+  final startsWithMinus = item.startsWith('-');
+
+  return dartKeywords.contains(item.toCamel) ||
+          startsWithNumber ||
+          startsWithMinus
       ? dart
-          ? 'value ${item.startsWith('-') ? 'minus' : ''} ${item.toCamel}'
-              .toCamel
-          : 'value ${item.startsWith('-') ? 'minus' : ''} ${item.toSnake}'
+          ? 'value ${startsWithMinus ? 'minus' : ''} ${item.toCamel}'.toCamel
+          : 'value ${startsWithMinus ? 'minus' : ''} ${item.toSnake}'
               .toScreamingSnake
       : dart
           ? item.toCamel


### PR DESCRIPTION
OpenApi:
```json
    "/api/bells/pagination": {
      "get": {
        "summary": "Read Bells Pagination",
        "operationId": "read_bells_pagination_api_bells_pagination_get",
        "parameters": [
          {
            "required": false,
            "schema": {
              "$ref": "#/components/schemas/SortOrder",
              "default": "asc"
            },
            "name": "sort_order",
            "in": "query"
          }
        ],
        "responses": {
          "200": {
            "description": "Successful Response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Page_BellInDb_"
                }
              }
            }
          }
        }
      }
    }
```

Before:
```dart
  @GET('/api/bells/pagination')
  Future<PageBellInDb> readBellsPaginationApiBellsPaginationGet({
    @Query('sort_order') SortOrder sortOrder = asc, // <-- error
  });
```
After:
```dart
  @GET('/api/bells/pagination')
  Future<PageBellInDb> readBellsPaginationApiBellsPaginationGet({
    @Query('sort_order') SortOrder sortOrder = SortOrder.asc,
  });
```