### PR TITLE
[WIP] Add functionality to evade conflicts and generate valid code

### DIFF
--- a/swagger_parser/lib/src/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/fill_controller.dart
@@ -66,6 +66,25 @@ final class FillController {
     );
   }
 
+  /// Return [GeneratedFile] generated from given [UniversalRestClient]
+  GeneratedFile fillExtentionContent() {
+    const name = 'extension';
+    final fileName = _programmingLanguage == ProgrammingLanguage.dart
+        ? '${name}_$_clientPostfix'.toSnake
+        : name.toPascal + _clientPostfix.toPascal;
+    const folderName ='extension';
+
+    return GeneratedFile(
+      name: '$folderName/$fileName.${_programmingLanguage.fileExtension}',
+      contents: _programmingLanguage.extensionFileContent(
+        name.toPascal + _clientPostfix.toPascal,
+        markFilesAsGenerated: _markFilesAsGenerated,
+      ),
+    );
+  }
+
+
+
   /// Return [GeneratedFile] root client generated from given clients
   GeneratedFile fillRootClient(Iterable<UniversalRestClient> clients) {
     final clientsNames = clients.map((c) => c.name.toPascal).toSet();

--- a/swagger_parser/lib/src/generator/generator.dart
+++ b/swagger_parser/lib/src/generator/generator.dart
@@ -230,6 +230,7 @@ final class Generator {
     for (final dataClass in _dataClasses) {
       files.add(fillController.fillDtoContent(dataClass));
     }
+    files.add(fillController.fillExtentionContent());
     if (_rootClient &&
         _programmingLanguage == ProgrammingLanguage.dart &&
         _restClients.isNotEmpty) {

--- a/swagger_parser/lib/src/generator/models/programming_language.dart
+++ b/swagger_parser/lib/src/generator/models/programming_language.dart
@@ -5,11 +5,13 @@ import '../templates/dart_enum_dto_template.dart';
 import '../templates/dart_freezed_dto_template.dart';
 import '../templates/dart_json_serializable_dto_template.dart';
 import '../templates/dart_retrofit_client_template.dart';
+import '../templates/dart_retrofit_extension_template.dart';
 import '../templates/dart_root_client_template.dart';
 import '../templates/dart_typedef_template.dart';
 import '../templates/kotlin_enum_dto_template.dart';
 import '../templates/kotlin_moshi_dto_template.dart';
 import '../templates/kotlin_retrofit_client_template.dart';
+import '../templates/kotlin_retrofit_extension_template.dart';
 import '../templates/kotlin_typedef_template.dart';
 import 'open_api_info.dart';
 import 'universal_data_class.dart';
@@ -103,6 +105,21 @@ enum ProgrammingLanguage {
           ),
         kotlin => kotlinRetrofitClientTemplate(
             restClient: restClient,
+            name: name,
+            markFileAsGenerated: markFilesAsGenerated,
+          ),
+      };
+
+  String extensionFileContent(
+    String name, {
+    required bool markFilesAsGenerated,
+  }) =>
+      switch (this) {
+        dart => dartRetrofitExtensionTemplate(
+            name: name,
+            markFileAsGenerated: markFilesAsGenerated,
+          ),
+        kotlin => kotlinRetrofitExtensionTemplate(
             name: name,
             markFileAsGenerated: markFilesAsGenerated,
           ),

--- a/swagger_parser/lib/src/generator/models/universal_type.dart
+++ b/swagger_parser/lib/src/generator/models/universal_type.dart
@@ -129,15 +129,15 @@ final class UniversalType {
 /// Converts [UniversalType] to type from specified language
 extension UniversalTypeX on UniversalType {
   /// Converts [UniversalType] to concrete type of certain [ProgrammingLanguage]
-  String toSuitableType(ProgrammingLanguage lang) {
+  String toSuitableType(ProgrammingLanguage lang, {bool isTypedef = false}) {
     if (arrayDepth == 0) {
-      return _questionMark(lang);
+      return _questionMark(lang, isTypedef);
     }
     final sb = StringBuffer();
     for (var i = 0; i < arrayDepth; i++) {
       sb.write('List<');
     }
-    sb.write(_questionMark(lang));
+    sb.write(_questionMark(lang, isTypedef));
     for (var i = 0; i < arrayDepth; i++) {
       sb.write('>');
     }
@@ -147,14 +147,15 @@ extension UniversalTypeX on UniversalType {
     return sb.toString();
   }
 
-  String _questionMark(ProgrammingLanguage lang) {
+  String _questionMark(ProgrammingLanguage lang, bool isTypedef) {
     final questionMark =
         isRequired && !nullable || arrayDepth > 0 || defaultValue != null
             ? ''
             : '?';
     switch (lang) {
       case ProgrammingLanguage.dart:
-        return type.toDartType(format) + questionMark;
+        // final type = type.toDartType(format) == type
+        return type.toDartType(isTypedef, format) + questionMark;
       case ProgrammingLanguage.kotlin:
         return type.toKotlinType(format) + questionMark;
     }

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -36,7 +36,7 @@ ${index != 0 && item.description != null ? '\n' : ''}${descriptionComment(item.d
 
 String _toJson(UniversalEnumClass enumClass, String className) => '''
 
-  ${enumClass.type.toDartType()} toJson() => _\$${className}EnumMap[this]!;
+  ${enumClass.type.toDartType(false)} toJson() => _\$${className}EnumMap[this]!;
 }
 
 const _\$${className}EnumMap = {

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -20,6 +20,7 @@ String dartRetrofitClientTemplate({
 ${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${_fileImport(restClient)}import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 ${dartImports(imports: restClient.imports, pathPrefix: '../models/')}
+import '../extension/extension_client.dart';
 part '${name.toSnake}.g.dart';
 
 @RestApi()

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -71,7 +71,7 @@ String _toParameter(UniversalRequestType parameter) =>
     "    @${parameter.parameterType.type}(${parameter.name != null ? "${parameter.parameterType.isPart ? 'name: ' : ''}'${parameter.name}'" : ''}) "
     '${_required(parameter.type)}'
     '${parameter.type.toSuitableType(ProgrammingLanguage.dart)} '
-    '${'${parameter.parameterType.type}${parameter.type.name!}'.toCamel}${_defaultValue(parameter.type)},';
+    '${'${parameter.parameterType.type} ${parameter.type.name!}'.toCamel}${_defaultValue(parameter.type)},';
 
 /// return required if isRequired
 String _required(UniversalType t) =>

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -71,7 +71,7 @@ String _toParameter(UniversalRequestType parameter) =>
     "    @${parameter.parameterType.type}(${parameter.name != null ? "${parameter.parameterType.isPart ? 'name: ' : ''}'${parameter.name}'" : ''}) "
     '${_required(parameter.type)}'
     '${parameter.type.toSuitableType(ProgrammingLanguage.dart)} '
-    '${'${parameter.parameterType.type}${parameter.type.name!.toPascal}'.toCamel}${_defaultValue(parameter.type)},';
+    '${'${parameter.parameterType.type} ${parameter.type.name!}'.toCamel}${_defaultValue(parameter.type)},';
 
 /// return required if isRequired
 String _required(UniversalType t) =>

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -71,7 +71,7 @@ String _toParameter(UniversalRequestType parameter) =>
     "    @${parameter.parameterType.type}(${parameter.name != null ? "${parameter.parameterType.isPart ? 'name: ' : ''}'${parameter.name}'" : ''}) "
     '${_required(parameter.type)}'
     '${parameter.type.toSuitableType(ProgrammingLanguage.dart)} '
-    '${parameter.type.name!.toCamel}${_defaultValue(parameter.type)},';
+    '${'${parameter.parameterType.type}${parameter.type.name!}'.toCamel}${_defaultValue(parameter.type)},';
 
 /// return required if isRequired
 String _required(UniversalType t) =>

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -71,7 +71,7 @@ String _toParameter(UniversalRequestType parameter) =>
     "    @${parameter.parameterType.type}(${parameter.name != null ? "${parameter.parameterType.isPart ? 'name: ' : ''}'${parameter.name}'" : ''}) "
     '${_required(parameter.type)}'
     '${parameter.type.toSuitableType(ProgrammingLanguage.dart)} '
-    '${'${parameter.parameterType.type} ${parameter.type.name!}'.toCamel}${_defaultValue(parameter.type)},';
+    '${'${parameter.parameterType.type}${parameter.type.name!.toPascal}'.toCamel}${_defaultValue(parameter.type)},';
 
 /// return required if isRequired
 String _required(UniversalType t) =>

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_extension_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_extension_template.dart
@@ -1,0 +1,25 @@
+import 'package:collection/collection.dart';
+
+import '../../utils/case_utils.dart';
+import '../../utils/type_utils.dart';
+import '../../utils/utils.dart';
+import '../models/programming_language.dart';
+import '../models/universal_request.dart';
+import '../models/universal_request_type.dart';
+import '../models/universal_rest_client.dart';
+import '../models/universal_type.dart';
+
+/// Provides template for generating dart Retrofit client
+String dartRetrofitExtensionTemplate({
+  required String name,
+  required bool markFileAsGenerated,
+}) {
+  final sb = StringBuffer(
+    '''
+extension Iso8061SerializableDateTime on DateTime {
+  String toJson() => toIso8601String();
+}
+''',
+  );
+  return sb.toString();
+}

--- a/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
@@ -21,5 +21,5 @@ String dartTypeDefTemplate(
     markFileAsGenerated: markFileAsGenerated,
   )}${import != null ? "import '${import.toSnake}.dart';\n\n" : ''}'
       '${descriptionComment(dataClass.description)}'
-      'typedef $className = ${type.toSuitableType(ProgrammingLanguage.dart)};\n';
+      'typedef $className = ${type.toSuitableType(ProgrammingLanguage.dart, isTypedef: true)};\n';
 }

--- a/swagger_parser/lib/src/generator/templates/kotlin_retrofit_extension_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_retrofit_extension_template.dart
@@ -1,0 +1,23 @@
+import '../../utils/case_utils.dart';
+import '../../utils/type_utils.dart';
+import '../../utils/utils.dart';
+import '../models/programming_language.dart';
+import '../models/universal_request.dart';
+import '../models/universal_request_type.dart';
+import '../models/universal_rest_client.dart';
+import '../models/universal_type.dart';
+
+/// Return file contents for kotlin retrofit client
+/// File contents are generated using universal rest client
+String kotlinRetrofitExtensionTemplate({
+  required String name,
+  required bool markFileAsGenerated,
+}) {
+  // TODO(Frumscepend): implement.
+  final sb = StringBuffer(
+    '''
+    //todo: implement
+    ''',
+  );
+  return sb.toString();
+}

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -787,7 +787,7 @@ class OpenApiParser {
             (map.containsKey(_propertiesConst) &&
                 (map[_propertiesConst] as Map<String, dynamic>).isNotEmpty) ||
         (map.containsKey(_additionalPropertiesConst) &&
-            (instanceof(map[_additionalPropertiesConst], Map<String, dynamic>)) &&
+            (map[_additionalPropertiesConst] is Map<String, dynamic>) &&
             (map[_additionalPropertiesConst] as Map<String, dynamic>)
                 .isNotEmpty)) {
       // false positive result

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:js_util';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
@@ -786,6 +787,7 @@ class OpenApiParser {
             (map.containsKey(_propertiesConst) &&
                 (map[_propertiesConst] as Map<String, dynamic>).isNotEmpty) ||
         (map.containsKey(_additionalPropertiesConst) &&
+            (instanceof(map[_additionalPropertiesConst], Map<String, dynamic>)) &&
             (map[_additionalPropertiesConst] as Map<String, dynamic>)
                 .isNotEmpty)) {
       // false positive result

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:js_util';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -18,8 +18,8 @@ extension StringTypeX on String {
           },
         'file' => 'File',
         'boolean' => 'bool',
-        'object' || 'null' => 'string',
-        _ => 'string'
+        'object' || 'null' => 'String',
+        _ => 'String'
       };
 
   String toKotlinType([String? format]) => switch (this) {

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -3,7 +3,7 @@ import 'case_utils.dart';
 import 'dart_keywords.dart';
 
 extension StringTypeX on String {
-  String toDartType([String? format]) => switch (this) {
+  String toDartType(bool isTypedef, [String? format]) => switch (this) {
         'integer' => 'int',
         'number' => switch (format) {
             'float' || 'double' => 'double',
@@ -19,7 +19,7 @@ extension StringTypeX on String {
         'file' => 'File',
         'boolean' => 'bool',
         'object' || 'null' => 'Object',
-        _ => this
+        _ => isTypedef ? 'String' : this
       };
 
   String toKotlinType([String? format]) => switch (this) {

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -18,7 +18,7 @@ extension StringTypeX on String {
           },
         'file' => 'File',
         'boolean' => 'bool',
-        'object' || 'null' => 'Object',
+        'object' || 'null' => isTypedef ? 'String' : 'Object',
         _ => isTypedef ? 'String' : this
       };
 

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -18,8 +18,8 @@ extension StringTypeX on String {
           },
         'file' => 'File',
         'boolean' => 'bool',
-        'object' || 'null' => 'Object',
-        _ => this
+        'object' || 'null' => 'string',
+        _ => 'string'
       };
 
   String toKotlinType([String? format]) => switch (this) {

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -18,8 +18,8 @@ extension StringTypeX on String {
           },
         'file' => 'File',
         'boolean' => 'bool',
-        'object' || 'null' => 'String',
-        _ => 'String'
+        'object' || 'null' => 'Object',
+        _ => this
       };
 
   String toKotlinType([String? format]) => switch (this) {


### PR DESCRIPTION
The problems:
1. Some typedef generating recurrent dependency if they not defined as model
2. If path and query parameters has the same name then generation makes variables of the same name. That is not an expected output.
3. Retrofit generating toJson for Date and Object types.

The solutions:
1. If typedef generation then replace possible `this` and `Object` to `String`
2. Added prefixes to client parameters equal to annotation name.
3. Added generation of extension for Date class and imported it in every client

TODO:
1.1. Research if it breaks anything
1.2. Make it for Kotlin generation if needed

2.1. Make it optional with control via hyperparameters
2.2. Handle situation when there are multiple parameters with same name. [rfc3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) not denying this.

3.1. Import extension only in classes that requiring it. 

4. Fix tests