### PR TITLE
Unknown enum value

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.11.0
 - Added unknown value to all enums to maintain backwards compatibility when adding new values on the backend
 - Add new config parameter `unknown_enum_value` (dart only) ([#106](https://github.com/Carapacik/swagger_parser/issues/106))
+- Support String values with spaces for enums ([#127](https://github.com/Carapacik/swagger_parser/issues/127))
 
 ## 1.10.6
 - Fixed map objects parsing as separate entities ([#124](https://github.com/Carapacik/swagger_parser/issues/124))

--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.0
+- Added unknown value to all enums to maintain backwards compatibility when adding new values on the backend
+- Add new config parameter `unknown_enum_value` (dart only) ([#106](https://github.com/Carapacik/swagger_parser/issues/106))
+
 ## 1.10.5
 - Fixed error with parsing dictionary objects ([#113](https://github.com/Carapacik/swagger_parser/issues/113))
 
@@ -5,7 +9,7 @@
 - Fixed error with `additionalProperties` ([#114](https://github.com/Carapacik/swagger_parser/issues/114))
 
 ## 1.10.3
-- Add new config parameter `original_http_response`(only for dart) ([#115](https://github.com/Carapacik/swagger_parser/issues/115))
+- Add new config parameter `original_http_response` (dart only) ([#115](https://github.com/Carapacik/swagger_parser/issues/115))
 
 ## 1.10.2
 - Fix error in `body` with name in dart template

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -107,6 +107,9 @@ swagger_parser:
   # Optional. Set 'true' to set enum prefix from parent component.
   enums_prefix: false
 
+  # Optional (dart only). Set 'true' to maintain backwards compatibility when adding new values on the backend.
+  unknown_enum_value: true
+
   # Optional. Set 'false' to not put a comment at the beginning of the generated files.
   mark_files_as_generated: true
 

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -53,6 +53,9 @@ swagger_parser:
   # Sets the OpenApi schema path directory for api definition.
   schema_path: schemas/openapi.json
 
+  # Sets the url of the OpenApi schema
+  schema_url: https://petstore.swagger.io/v2/swagger.json
+  
   # Required. Sets output directory for generated files (Clients and DTOs).
   output_directory: lib/api
 

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -53,9 +53,6 @@ swagger_parser:
   # Sets the OpenApi schema path directory for api definition.
   schema_path: schemas/openapi.json
 
-  # Sets the url of the OpenApi schema
-  schema_url: https://petstore.swagger.io/v2/swagger.json
-
   # Required. Sets output directory for generated files (Clients and DTOs).
   output_directory: lib/api
 

--- a/swagger_parser/example/swagger_parser.yaml
+++ b/swagger_parser/example/swagger_parser.yaml
@@ -58,6 +58,9 @@ swagger_parser:
   # Optional. Set 'true' to set enum prefix from parent component.
   enums_prefix: false
 
+  # Optional (dart only). Set 'true' to maintain backwards compatibility when adding new values on the backend.
+  unknown_enum_value: true
+
   # Optional. Set 'false' to not put a comment at the beginning of the generated files.
   mark_files_as_generated: true
 

--- a/swagger_parser/lib/src/config/yaml_config.dart
+++ b/swagger_parser/lib/src/config/yaml_config.dart
@@ -36,6 +36,7 @@ final class YamlConfig {
     this.putInFolder,
     this.enumsToJson,
     this.enumsPrefix,
+    this.unknownEnumValue,
     this.markFilesAsGenerated,
     this.originalHttpResponse,
     this.replacementRules = const [],
@@ -203,6 +204,13 @@ final class YamlConfig {
       );
     }
 
+    final unknownEnumValue = yamlConfig['unknown_enum_value'];
+    if (unknownEnumValue is! bool?) {
+      throw const ConfigException(
+        "Config parameter 'unknown_enum_value' must be bool.",
+      );
+    }
+
     final markFilesAsGenerated = yamlConfig['mark_files_as_generated'];
     if (markFilesAsGenerated is! bool?) {
       throw const ConfigException(
@@ -266,6 +274,7 @@ final class YamlConfig {
           originalHttpResponse ?? rootConfig?.originalHttpResponse,
       enumsToJson: enumsToJson ?? rootConfig?.enumsToJson,
       enumsPrefix: enumsPrefix ?? rootConfig?.enumsPrefix,
+      unknownEnumValue: unknownEnumValue ?? rootConfig?.unknownEnumValue,
       markFilesAsGenerated:
           markFilesAsGenerated ?? rootConfig?.markFilesAsGenerated,
       replacementRules: replacementRules ?? rootConfig?.replacementRules ?? [],
@@ -361,6 +370,7 @@ final class YamlConfig {
   final bool? putInFolder;
   final bool? enumsToJson;
   final bool? enumsPrefix;
+  final bool? unknownEnumValue;
   final bool? markFilesAsGenerated;
   final bool? originalHttpResponse;
   final List<ReplacementRule> replacementRules;

--- a/swagger_parser/lib/src/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/fill_controller.dart
@@ -16,6 +16,7 @@ final class FillController {
     bool putClientsInFolder = false,
     bool freezed = false,
     bool enumsToJson = false,
+    bool unknownEnumValue = true,
     bool markFilesAsGenerated = false,
   })  : _openApiInfo = openApiInfo,
         _clientPostfix = clientPostfix,
@@ -24,6 +25,7 @@ final class FillController {
         _putClientsInFolder = putClientsInFolder,
         _freezed = freezed,
         _enumsToJson = enumsToJson,
+        _unknownEnumValue = unknownEnumValue,
         _markFilesAsGenerated = markFilesAsGenerated;
 
   final OpenApiInfo _openApiInfo;
@@ -33,6 +35,7 @@ final class FillController {
   final bool _freezed;
   final bool _putClientsInFolder;
   final bool _enumsToJson;
+  final bool _unknownEnumValue;
   final bool _markFilesAsGenerated;
 
   /// Return [GeneratedFile] generated from given [UniversalDataClass]
@@ -44,6 +47,7 @@ final class FillController {
           dataClass,
           freezed: _freezed,
           enumsToJson: _enumsToJson,
+          unknownEnumValue: _unknownEnumValue,
           markFilesAsGenerated: _markFilesAsGenerated,
         ),
       );

--- a/swagger_parser/lib/src/generator/generator.dart
+++ b/swagger_parser/lib/src/generator/generator.dart
@@ -45,6 +45,7 @@ final class Generator {
     bool? putInFolder,
     bool? enumsToJson,
     bool? enumsPrefix,
+    bool? unknownEnumValue,
     bool? markFilesAsGenerated,
     List<ReplacementRule>? replacementRules,
   })  : _schemaPath = schemaPath,
@@ -67,6 +68,7 @@ final class Generator {
         _putInFolder = putInFolder ?? false,
         _enumsToJson = enumsToJson ?? false,
         _enumsPrefix = enumsPrefix ?? false,
+        unknownEnumValue = unknownEnumValue ?? true,
         _markFilesAsGenerated = markFilesAsGenerated ?? true,
         _replacementRules = replacementRules ?? const [];
 
@@ -91,6 +93,7 @@ final class Generator {
       putInFolder: yamlConfig.putInFolder,
       enumsToJson: yamlConfig.enumsToJson,
       enumsPrefix: yamlConfig.enumsPrefix,
+      unknownEnumValue: yamlConfig.unknownEnumValue,
       markFilesAsGenerated: yamlConfig.markFilesAsGenerated,
       replacementRules: yamlConfig.replacementRules,
     );
@@ -155,6 +158,9 @@ final class Generator {
 
   /// If true, generated enums will have parent component name in its class name
   final bool _enumsPrefix;
+
+  /// If true, adds an unknown value for all enums to maintain backward compatibility when adding new values on the backend.
+  final bool unknownEnumValue;
 
   /// If true, generated files will be marked as generated
   final bool _markFilesAsGenerated;
@@ -293,6 +299,7 @@ final class Generator {
       freezed: _freezed,
       putClientsInFolder: _putClientsInFolder,
       enumsToJson: _enumsToJson,
+      unknownEnumValue: unknownEnumValue,
       markFilesAsGenerated: _markFilesAsGenerated,
     );
     final files = <GeneratedFile>[];

--- a/swagger_parser/lib/src/generator/models/programming_language.dart
+++ b/swagger_parser/lib/src/generator/models/programming_language.dart
@@ -38,6 +38,7 @@ enum ProgrammingLanguage {
     UniversalDataClass dataClass, {
     required bool freezed,
     required bool enumsToJson,
+    required bool unknownEnumValue,
     required bool markFilesAsGenerated,
   }) {
     switch (this) {
@@ -47,6 +48,7 @@ enum ProgrammingLanguage {
             dataClass,
             freezed: freezed,
             enumsToJson: enumsToJson,
+            unknownEnumValue: unknownEnumValue,
             markFileAsGenerated: markFilesAsGenerated,
           );
         } else if (dataClass is UniversalComponentClass) {

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -44,7 +44,7 @@ String _enumValue(
 ) =>
     '''
 ${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})
-  ${item.name.toCamel}('${item.jsonKey}')''';
+  ${item.name.toCamel}(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})''';
 
 String _toJson(UniversalEnumClass enumClass, String className) =>
     '\n\n  ${enumClass.type.toDartType()}? toJson() => json;';

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -10,9 +10,20 @@ String dartEnumDtoTemplate(
   UniversalEnumClass enumClass, {
   required bool freezed,
   required bool enumsToJson,
+  required bool unknownEnumValue,
   required bool markFileAsGenerated,
 }) {
   final className = enumClass.name.toPascal;
+  final jsonParam = unknownEnumValue || enumsToJson;
+
+  final values =
+      '${enumClass.items.mapIndexed((i, e) => _enumValue(i, enumClass.type, e, jsonParam: jsonParam)).join(',\n')}${unknownEnumValue ? ',' : ';'}';
+  final unkownEnumValueStr = unknownEnumValue ? _unkownEnumValue() : '';
+  final constructorStr = jsonParam ? _constructor(className) : '';
+  final fromJsonStr = unknownEnumValue ? _fromJson(className, enumClass) : '';
+  final jsonFieldStr = jsonParam ? _jsonField(enumClass) : '';
+  final toJsonStr = enumsToJson ? _toJson(enumClass, className) : '';
+
   return '''
 ${generatedFileComment(
     markFileAsGenerated: markFileAsGenerated,
@@ -20,31 +31,39 @@ ${generatedFileComment(
 
 ${descriptionComment(enumClass.description)}@JsonEnum()
 enum $className {
-${enumClass.items.mapIndexed((i, e) => _enumValue(i, enumClass.type, e)).join(',\n')},
+$values$unkownEnumValueStr$constructorStr$fromJsonStr$jsonFieldStr$toJsonStr
+}
+''';
+}
+
+String _constructor(String className) => '\n\n  const $className(this.json);\n';
+
+String _jsonField(UniversalEnumClass enumClass) =>
+    '\n  final ${enumClass.type.toDartType()}? json;';
+
+String _unkownEnumValue() => r'''
+
 
   /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
-  \$unknown(null);
+  $unknown(null);''';
 
-  const $className(this.json);
+String _fromJson(String className, UniversalEnumClass enumClass) => '''
 
   factory $className.fromJson(${enumClass.type.toDartType()} json) => values.firstWhere(
         (e) => e.json == json,
         orElse: () => \$unknown,
       );
-
-  final ${enumClass.type.toDartType()}? json;${enumsToJson ? _toJson(enumClass, className) : ''}
-}
 ''';
-}
 
 String _enumValue(
   int index,
   String type,
-  UniversalEnumItem item,
-) =>
+  UniversalEnumItem item, {
+  required bool jsonParam,
+}) =>
     '''
 ${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})
-  ${item.name.toCamel}(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})''';
+  ${item.name.toCamel}${jsonParam ? '(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})' : ''}''';
 
 String _toJson(UniversalEnumClass enumClass, String className) =>
     '\n\n  ${enumClass.type.toDartType()}? toJson() => json;';

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -27,7 +27,7 @@ ${enumClass.items.mapIndexed((i, e) => _enumValue(i, enumClass.type, e)).join(',
 
   const $className(this.json);
 
-  factory $className.fromJson(String json) => values.firstWhere(
+  factory $className.fromJson(${enumClass.type.toDartType()} json) => values.firstWhere(
         (e) => e.json == json,
         orElse: () => \$unknown,
       );

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -20,28 +20,31 @@ ${generatedFileComment(
 
 ${descriptionComment(enumClass.description)}@JsonEnum()
 enum $className {
-${enumClass.items.mapIndexed((i, e) => _jsonValue(i, enumClass.type, e)).join(',\n')};
-${enumsToJson ? _toJson(enumClass, className) : '}'}
+${enumClass.items.mapIndexed((i, e) => _enumValue(i, enumClass.type, e)).join(',\n')},
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  \$unknown(null);
+
+  const $className(this.json);
+
+  factory $className.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => \$unknown,
+      );
+
+  final ${enumClass.type.toDartType()}? json;${enumsToJson ? _toJson(enumClass, className) : ''}
+}
 ''';
 }
 
-String _jsonValue(
+String _enumValue(
   int index,
   String type,
   UniversalEnumItem item,
 ) =>
     '''
-${index != 0 && item.description != null ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})
-  ${item.name.toCamel}''';
+${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue(${type == 'string' ? "'${item.jsonKey}'" : item.jsonKey})
+  ${item.name.toCamel}('${item.jsonKey}')''';
 
-String _toJson(UniversalEnumClass enumClass, String className) => '''
-
-  ${enumClass.type.toDartType()} toJson() => _\$${className}EnumMap[this]!;
-}
-
-const _\$${className}EnumMap = {
-  ${enumClass.items.map(
-          (e) => '$className.${e.name.toCamel}: '
-              '${enumClass.type == 'string' ? "'" : ''}${e.jsonKey}${enumClass.type == 'string' ? "'" : ''}',
-        ).join(',\n  ')},
-};''';
+String _toJson(UniversalEnumClass enumClass, String className) =>
+    '\n\n  ${enumClass.type.toDartType()}? toJson() => json;';

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -84,5 +84,5 @@ String _required(UniversalType t) =>
 String _defaultValue(UniversalType t) => t.defaultValue != null
     ? ' = '
         '${t.arrayDepth > 0 ? 'const ' : ''}'
-        '${t.enumType != null ? '${t.type}.${protectDefaultEnum(t.defaultValue)?.toCamel}' : protectDefaultValue(t.defaultValue, type: t.type)}'
+        '${t.enumType != null ? '${t.type}.${protectDefaultEnum(t.defaultValue?.toCamel)?.toCamel}' : protectDefaultValue(t.defaultValue, type: t.type)}'
     : '';

--- a/swagger_parser/lib/src/generator/templates/kotlin_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_retrofit_client_template.dart
@@ -67,5 +67,5 @@ String _toQueryParameter(UniversalRequestType parameter) =>
 /// return defaultValue if have
 String _defaultValue(UniversalType t) => t.defaultValue != null
     ? ' = '
-        '${t.enumType != null ? '${t.type}.${protectDefaultEnum(t.defaultValue)?.toScreamingSnake}' : protectDefaultValue(t.defaultValue, type: t.type, dart: false)}'
+        '${t.enumType != null ? '${t.type}.${protectDefaultEnum(t.defaultValue?.toScreamingSnake)?.toScreamingSnake}' : protectDefaultValue(t.defaultValue, type: t.type, dart: false)}'
     : '';

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -61,7 +61,7 @@ String uniqueName({bool isEnum = false}) {
   return name;
 }
 
-final _enumNameRegExp = RegExp(r'^[a-zA-Z\d_-]*$');
+final _enumNameRegExp = RegExp(r'^[a-zA-Z\d_-\s]*$');
 final _startWithNumberRegExp = RegExp(r'^-?\d+');
 
 /// Protect default enum value from incorrect symbols, keywords, etc.

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1097,7 +1097,7 @@ class ClassName with _$ClassName {
           ),
         ];
 
-        const fillController = FillController();
+        const fillController = FillController(unknownEnumValue: false);
         final files = <GeneratedFile>[];
         for (final enumClass in dataClasses) {
           files.add(fillController.fillDtoContent(enumClass));
@@ -1109,8 +1109,10 @@ import 'package:json_annotation/json_annotation.dart';
 enum EnumName {
   @JsonValue(1)
   value1,
+
   @JsonValue(2)
   value2,
+
   @JsonValue(3)
   value3;
 }
@@ -1123,10 +1125,13 @@ import 'package:json_annotation/json_annotation.dart';
 enum EnumNameString {
   @JsonValue('itemOne')
   itemOne,
+
   @JsonValue('ItemTwo')
   itemTwo,
+
   @JsonValue('item_three')
   itemThree,
+
   @JsonValue('ITEM-FOUR')
   itemFour,
 
@@ -1161,10 +1166,13 @@ import 'package:json_annotation/json_annotation.dart';
 enum EnumNameStringWithLeadingNumbers {
   @JsonValue('1itemOne')
   value1itemOne,
+
   @JsonValue('2ItemTwo')
   value2ItemTwo,
+
   @JsonValue('3item_three')
   value3itemThree,
+
   @JsonValue('4ITEM-FOUR')
   value4ItemFour,
 
@@ -1196,56 +1204,57 @@ enum EnumNameStringWithLeadingNumbers {
           ),
         ];
 
-        const fillController = FillController(enumsToJson: true);
+        const fillController =
+            FillController(enumsToJson: true, unknownEnumValue: false);
         final files = <GeneratedFile>[];
         for (final enumClass in dataClasses) {
           files.add(fillController.fillDtoContent(enumClass));
         }
-        const expectedContent0 = r'''
+        const expectedContent0 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
 enum EnumName {
   @JsonValue(1)
-  value1,
+  value1(1),
+
   @JsonValue(2)
-  value2,
+  value2(2),
+
   @JsonValue(3)
-  value3;
+  value3(3);
 
-  int toJson() => _$EnumNameEnumMap[this]!;
+  const EnumName(this.json);
+
+  final int? json;
+
+  int? toJson() => json;
 }
-
-const _$EnumNameEnumMap = {
-  EnumName.value1: 1,
-  EnumName.value2: 2,
-  EnumName.value3: 3,
-};
 ''';
 
-        const expectedContent1 = r'''
+        const expectedContent1 = '''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
 enum EnumNameString {
   @JsonValue('itemOne')
-  itemOne,
+  itemOne('itemOne'),
+
   @JsonValue('ItemTwo')
-  itemTwo,
+  itemTwo('ItemTwo'),
+
   @JsonValue('item_three')
-  itemThree,
+  itemThree('item_three'),
+
   @JsonValue('ITEM-FOUR')
-  itemFour;
+  itemFour('ITEM-FOUR');
 
-  String toJson() => _$EnumNameStringEnumMap[this]!;
+  const EnumNameString(this.json);
+
+  final String? json;
+
+  String? toJson() => json;
 }
-
-const _$EnumNameStringEnumMap = {
-  EnumNameString.itemOne: 'itemOne',
-  EnumNameString.itemTwo: 'ItemTwo',
-  EnumNameString.itemThree: 'item_three',
-  EnumNameString.itemFour: 'ITEM-FOUR',
-};
 ''';
 
         expect(files[0].contents, expectedContent0);
@@ -1274,7 +1283,8 @@ const _$EnumNameStringEnumMap = {
             items: UniversalEnumItem.listFromNames({'FALSE', 'for', 'do'}),
           ),
         ];
-        const fillController = FillController(freezed: true);
+        const fillController =
+            FillController(freezed: true, unknownEnumValue: false);
         final files = <GeneratedFile>[];
         for (final enumClass in dataClasses) {
           files.add(fillController.fillDtoContent(enumClass));
@@ -1286,8 +1296,10 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 enum EnumName {
   @JsonValue(1)
   value1,
+
   @JsonValue(2)
   value2,
+
   @JsonValue(3)
   value3;
 }
@@ -1300,10 +1312,13 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 enum EnumNameString {
   @JsonValue('itemOne')
   itemOne,
+
   @JsonValue('ItemTwo')
   itemTwo,
+
   @JsonValue('item_three')
   itemThree,
+
   @JsonValue('ITEM-FOUR')
   itemFour;
 }
@@ -1358,20 +1373,28 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 @JsonEnum()
 enum EnumName {
   @JsonValue(1)
-  value1,
+  value1(1),
+
   @JsonValue(2)
-  value2,
+  value2(2),
+
   @JsonValue(3)
-  value3;
+  value3(3),
 
-  int toJson() => _$EnumNameEnumMap[this]!;
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const EnumName(this.json);
+
+  factory EnumName.fromJson(int json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final int? json;
+
+  int? toJson() => json;
 }
-
-const _$EnumNameEnumMap = {
-  EnumName.value1: 1,
-  EnumName.value2: 2,
-  EnumName.value3: 3,
-};
 ''';
 
         const expectedContent1 = r'''
@@ -1380,23 +1403,31 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 @JsonEnum()
 enum EnumNameString {
   @JsonValue('itemOne')
-  itemOne,
+  itemOne('itemOne'),
+
   @JsonValue('ItemTwo')
-  itemTwo,
+  itemTwo('ItemTwo'),
+
   @JsonValue('item_three')
-  itemThree,
+  itemThree('item_three'),
+
   @JsonValue('ITEM-FOUR')
-  itemFour;
+  itemFour('ITEM-FOUR'),
 
-  String toJson() => _$EnumNameStringEnumMap[this]!;
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const EnumNameString(this.json);
+
+  factory EnumNameString.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  String? toJson() => json;
 }
-
-const _$EnumNameStringEnumMap = {
-  EnumNameString.itemOne: 'itemOne',
-  EnumNameString.itemTwo: 'ItemTwo',
-  EnumNameString.itemThree: 'item_three',
-  EnumNameString.itemFour: 'ITEM-FOUR',
-};
 ''';
         expect(files[0].contents, expectedContent0);
         expect(files[1].contents, expectedContent1);
@@ -1495,19 +1526,34 @@ enum class KeywordsName {
       const fillController = FillController();
       final file = fillController.fillDtoContent(dataClass);
 
-      const expectedContent = '''
+      const expectedContent = r'''
 import 'package:json_annotation/json_annotation.dart';
 
 @JsonEnum()
 enum EnumName {
   @JsonValue(-2)
-  valueMinus2,
+  valueMinus2(-2),
+
   @JsonValue(-1)
-  valueMinus1,
+  valueMinus1(-1),
+
   @JsonValue(0)
-  value0,
+  value0(0),
+
   @JsonValue(1)
-  value1;
+  value1(1),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const EnumName(this.json);
+
+  factory EnumName.fromJson(int json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final int? json;
 }
 ''';
 
@@ -1523,19 +1569,34 @@ enum EnumName {
       const fillController = FillController(freezed: true);
       final file = fillController.fillDtoContent(dataClass);
 
-      const expectedContent = '''
+      const expectedContent = r'''
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
 enum EnumName {
   @JsonValue(-2)
-  valueMinus2,
+  valueMinus2(-2),
+
   @JsonValue(-1)
-  valueMinus1,
+  valueMinus1(-1),
+
   @JsonValue(0)
-  value0,
+  value0(0),
+
   @JsonValue(1)
-  value1;
+  value1(1),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const EnumName(this.json);
+
+  factory EnumName.fromJson(int json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final int? json;
 }
 ''';
 

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1092,6 +1092,7 @@ class ClassName with _$ClassName {
                 '3item_three',
                 '4ITEM-FOUR',
                 '5иллегалчарактер',
+                '6 item six',
               },
             ),
           ),
@@ -1178,7 +1179,10 @@ enum EnumNameStringWithLeadingNumbers {
 
   /// Incorrect name has been replaced. Original name: `5иллегалчарактер`.
   @JsonValue('5иллегалчарактер')
-  undefined0;
+  undefined0,
+
+  @JsonValue('6 item six')
+  value6ItemSix;
 }
 ''';
 
@@ -1357,7 +1361,7 @@ enum KeywordsName {
             name: 'EnumNameString',
             type: 'string',
             items: UniversalEnumItem.listFromNames(
-              {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR'},
+              {'itemOne', 'ItemTwo', 'item_three', 'ITEM-FOUR', 'Item five'},
             ),
           ),
         ];
@@ -1413,6 +1417,9 @@ enum EnumNameString {
 
   @JsonValue('ITEM-FOUR')
   itemFour('ITEM-FOUR'),
+
+  @JsonValue('Item five')
+  itemFive('Item five'),
 
   /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
   $unknown(null);


### PR DESCRIPTION
Adds an unknown value for all enums to maintain backward compatibility when adding new values on the backend. https://github.com/Carapacik/swagger_parser/issues/106

Support String values with spaces for enums. https://github.com/Carapacik/swagger_parser/issues/127