### PR TITLE
fix: getting first available content type for parametersV2 method

### DIFF
--- a/swagger_parser/lib/src/generator/models/universal_request.dart
+++ b/swagger_parser/lib/src/generator/models/universal_request.dart
@@ -59,6 +59,7 @@ final class UniversalRequest {
           runtimeType == other.runtimeType &&
           name == other.name &&
           requestType == other.requestType &&
+          contentType == other.contentType &&
           route == other.route &&
           returnType == other.returnType &&
           const DeepCollectionEquality().equals(parameters, other.parameters) &&
@@ -71,6 +72,7 @@ final class UniversalRequest {
       requestType.hashCode ^
       route.hashCode ^
       returnType.hashCode ^
+      contentType.hashCode ^
       parameters.hashCode ^
       isMultiPart.hashCode ^
       isFormUrlEncoded.hashCode;

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -398,6 +398,8 @@ class OpenApiParser {
           resultContentType = _multipartFormDataConst;
         } else if (consumes.contains(_formUrlEncodedConst)) {
           resultContentType = _formUrlEncodedConst;
+        } else if (consumes.isNotEmpty && consumes.first != null) {
+          resultContentType = consumes.first as String;
         }
       }
       for (final parameter in map[_parametersConst] as List<dynamic>) {

--- a/swagger_parser/test/parser/requests_test.dart
+++ b/swagger_parser/test/parser/requests_test.dart
@@ -26,6 +26,7 @@ void main() {
               requestType: HttpRequestType.post,
               route: '/api/Auth/register',
               returnType: UniversalType(type: 'string'),
+              contentType: 'text/json',
               parameters: [
                 UniversalRequestType(
                   parameterType: HttpParameterType.body,
@@ -110,7 +111,7 @@ void main() {
         ),
       ];
       for (var i = 0; i < actualRestClients.length; i++) {
-        expect(actualRestClients.last, expectedRestClients.last);
+        expect(actualRestClients[i], expectedRestClients[i]);
       }
     });
 

--- a/swagger_parser/test/parser/schemas/basic_requests.2.0.json
+++ b/swagger_parser/test/parser/schemas/basic_requests.2.0.json
@@ -7,8 +7,8 @@
           "Auth"
         ],
         "consumes": [
-          "application/json",
           "text/json",
+          "application/json",
           "application/*+json"
         ],
         "produces": [


### PR DESCRIPTION
I added another check in the parametersV2 method so that if there is a content type which is not multipart or form url encoded it is added to the request.
For example, I would expect the following swagger:
```json
{
  "swagger": "2.0",
  "info": {
    "description": "",
    "version": "",
    "title": "Test swagger"
  },
  "host": "localhost:8081",
  "basePath": "/",
  "tags": [
    {
      "name": "Tests",
      "description": "Test Controller"
    }
  ],
  "paths": {
    "/test": {
      "patch": {
        "tags": [
          "Tests"
        ],
        "description": "Description",
        "operationId": "operationId",
        "consumes": [
          "application/json-patch+json"
        ],
        "produces": [
          "application/json"
        ],
        "parameters": [],
        "responses": {
          "200": {
            "description": "Success"
          }
        }
      }
    }
  },
  "definitions": {}
}
```
to generate the following dart code:
```dart
@RestApi()
abstract class TestsClient {
  factory TestsClient(Dio dio, {String? baseUrl}) = _TestsClient;

  /// Description
  @Headers(<String, String>{'Content-Type': 'application/json-patch+json'})
  @PATCH('/test')
  Future<void> operationId();
}
```

But instead generates this (the `@Headers` annotation is missing):
```dart
@RestApi()
abstract class TestsClient {
  factory TestsClient(Dio dio, {String? baseUrl}) = _TestsClient;

  /// Description
  @PATCH('/test')
  Future<void> operationId();
}
```

I also fixed the parser `request_tests` for v2 (calling`actualRestClient.last` in that scenario always returns the same element, therefore not all the list element were properly compared). The `basic paths check 3.0` test has the same issue, if you switch from 
```dart
expect(actualRestClients.last, expectedRestClients.last);
```
to 
```dart
expect(actualRestClients[i], expectedRestClients[i]);
```
the test fails, it seems that the returnType is different but I didn't manage to understand why.