### PR TITLE
fix: Path-level parameters no longer cause crash.

### DIFF
--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -9,6 +9,7 @@ topics:
   - codegen
   - api
   - json
+
 environment:
   sdk: ^3.0.0
 


### PR DESCRIPTION

Fixes issue: https://github.com/Carapacik/swagger_parser/issues/147 