### PR TITLE
Skip parameters and Remove tag special characters

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 1.15.0
-- Remove special characters from tags
-- Add new config parameter `skip_parameters`
-
 ## 1.14.0
 - Fixed error with empty content type
 - Fixed retrofit template
+- Remove special characters from tags
+- Add new config parameter `skip_parameters`
 
 ## 1.13.1
 - Fixed error with path-level parameters cause crash ([#147](https://github.com/Carapacik/swagger_parser/issues/147))

--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.0
+- Remove special characters from tags
+- Add new config parameter `skip_parameters`
+
 ## 1.14.0
 - Fixed error with empty content type
 - Fixed retrofit template

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -134,6 +134,10 @@ swagger_parser:
     # Example of rule
     - pattern: "[0-9]+"
       replacement: ""
+
+  # Optional. Skip parameters.
+  skip_parameters:
+    - 'X-Rider-Token'
 ```
 
 For multiple schemes:

--- a/swagger_parser/lib/src/config/yaml_config.dart
+++ b/swagger_parser/lib/src/config/yaml_config.dart
@@ -291,7 +291,7 @@ final class YamlConfig {
             "Config parameter 'skip_fields' values must be List of String.",
           );
         }
-      skipParameters.add(element);
+        skipParameters.add(element);
       }
     }
 

--- a/swagger_parser/lib/src/config/yaml_config.dart
+++ b/swagger_parser/lib/src/config/yaml_config.dart
@@ -43,6 +43,7 @@ final class YamlConfig {
     this.originalHttpResponse,
     this.defaultContentType,
     this.replacementRules = const [],
+    this.skipParameters = const [],
   });
 
   /// Applies parameters from YAML file
@@ -276,6 +277,24 @@ final class YamlConfig {
       }
     }
 
+    final rawSkipParameters = yamlConfig['skip_parameters'];
+    if (rawSkipParameters is! YamlList?) {
+      throw const ConfigException(
+        "Config parameter 'skip_fields' must be list.",
+      );
+    }
+    final skipParameters = <String>[];
+    if (rawSkipParameters != null) {
+      for (final element in rawSkipParameters) {
+        if (element is! String) {
+          throw const ConfigException(
+            "Config parameter 'skip_fields' values must be List of String.",
+          );
+        }
+      skipParameters.add(element);
+      }
+    }
+
     return YamlConfig(
       name: name,
       schemaPath: schemaPath,
@@ -303,6 +322,7 @@ final class YamlConfig {
           markFilesAsGenerated ?? rootConfig?.markFilesAsGenerated,
       defaultContentType: defaultContentType ?? rootConfig?.defaultContentType,
       replacementRules: replacementRules ?? rootConfig?.replacementRules ?? [],
+      skipParameters: skipParameters,
     );
   }
 
@@ -401,4 +421,5 @@ final class YamlConfig {
   final String? defaultContentType;
   final bool? originalHttpResponse;
   final List<ReplacementRule> replacementRules;
+  final List<String> skipParameters;
 }

--- a/swagger_parser/lib/src/generator/generator.dart
+++ b/swagger_parser/lib/src/generator/generator.dart
@@ -51,6 +51,7 @@ final class Generator {
     String? defaultContentType,
     bool? markFilesAsGenerated,
     List<ReplacementRule>? replacementRules,
+    List<String>? skipParameters,
   })  : _schemaPath = schemaPath,
         _schemaUrl = schemaUrl,
         _schemaContent = schemaContent,
@@ -75,7 +76,8 @@ final class Generator {
         _unknownEnumValue = unknownEnumValue ?? true,
         _markFilesAsGenerated = markFilesAsGenerated ?? true,
         _defaultContentType = defaultContentType ?? 'application/json',
-        _replacementRules = replacementRules ?? const [];
+        _replacementRules = replacementRules ?? const [],
+        _skipParameters = skipParameters ?? const [];
 
   /// Applies parameters set from yaml config file
   factory Generator.fromYamlConfig(YamlConfig yamlConfig) {
@@ -102,6 +104,7 @@ final class Generator {
       unknownEnumValue: yamlConfig.unknownEnumValue,
       markFilesAsGenerated: yamlConfig.markFilesAsGenerated,
       replacementRules: yamlConfig.replacementRules,
+      skipParameters: yamlConfig.skipParameters,
     );
   }
 
@@ -179,6 +182,9 @@ final class Generator {
 
   /// List of rules used to replace patterns in generated class names
   final List<ReplacementRule> _replacementRules;
+
+  /// Skip parameters when generate
+  final List<String> _skipParameters;
 
   /// Result open api info
   late final OpenApiInfo _openApiInfo;
@@ -283,6 +289,7 @@ final class Generator {
       replacementRules: _replacementRules,
       originalHttpResponse: _originalHttpResponse,
       defaultContentType: _defaultContentType,
+      skipParameters: _skipParameters,
     );
     _openApiInfo = parser.parseOpenApiInfo();
     _restClients = parser.parseRestClients();

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -779,7 +779,10 @@ class OpenApiParser {
   String _getTag(Map<String, dynamic> map) => _squashClients && _name != null
       ? _name!
       : map.containsKey(_tagsConst)
-          ? (map[_tagsConst] as List<dynamic>).first.toString().replaceAll(RegExp(r'[^\w\s]+'), '') // Remove special characters
+          ? (map[_tagsConst] as List<dynamic>)
+              .first
+              .toString()
+              .replaceAll(RegExp(r'[^\w\s]+'), '') // Remove special characters
           : 'client';
 
   /// Format `$ref` type


### PR DESCRIPTION
Sometimes it is useful to skip some parameters.

If tags contain special characters, an invalid client will be generated.

@Carapacik Hi, I have added the changelog of 1.15.0 and recreated create a PR with latest code. :)