### PR TITLE
Fix/map additional properties ref

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.14.1
+- Removed check that would avoid generating a map when additional properties has a `$ref` value 
+
 ## 1.14.0
 - Fixed error with empty content type
 - Fixed retrofit template

--- a/swagger_parser/lib/src/generator/models/universal_type.dart
+++ b/swagger_parser/lib/src/generator/models/universal_type.dart
@@ -131,7 +131,7 @@ final class UniversalType {
 
   @override
   String toString() =>
-      'UniversalType(\ntype: $type,\nname: $name,\ndescription: $description,\nformat: $format,\njsonKey: $jsonKey,\ndefaultValue: $defaultValue,\nisRequired: $isRequired,\nenumType: $enumType,\narrayDepth: $arrayDepth,\nnullable: $nullable\n)';
+      'UniversalType(\ntype: $type,\nname: $name,\ndescription: $description,\nformat: $format,\njsonKey: $jsonKey,\ndefaultValue: $defaultValue,\nisRequired: $isRequired,\nenumType: $enumType,\narrayDepth: $arrayDepth,\nnullable: $nullable\n, mapType: $mapType\n)';
 }
 
 /// Converts [UniversalType] to type from specified language
@@ -158,6 +158,7 @@ extension UniversalTypeX on UniversalType {
     if (nullable || (!isRequired && defaultValue == null)) {
       sb.write('?');
     }
+    print(sb.toString());
     return sb.toString();
   }
 

--- a/swagger_parser/lib/src/generator/models/universal_type.dart
+++ b/swagger_parser/lib/src/generator/models/universal_type.dart
@@ -158,7 +158,6 @@ extension UniversalTypeX on UniversalType {
     if (nullable || (!isRequired && defaultValue == null)) {
       sb.write('?');
     }
-    print(sb.toString());
     return sb.toString();
   }
 

--- a/swagger_parser/lib/src/parser/parser.dart
+++ b/swagger_parser/lib/src/parser/parser.dart
@@ -1075,9 +1075,7 @@ class OpenApiParser {
       // To detect is this entity is map or not
       final mapType = map[_typeConst].toString() == _objectConst &&
               map.containsKey(_additionalPropertiesConst) &&
-              (map[_additionalPropertiesConst] is Map<String, dynamic>) &&
-              !(map[_additionalPropertiesConst] as Map<String, dynamic>)
-                  .containsKey(_refConst)
+              (map[_additionalPropertiesConst] is Map<String, dynamic>)
           ? 'string'
           : null;
       final defaultValue = map[_defaultConst]?.toString();

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.14.0
+version: 1.14.1
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 homepage: https://omega-r.com
 topics:

--- a/swagger_parser/test/parser/data_classes_test.dart
+++ b/swagger_parser/test/parser/data_classes_test.dart
@@ -450,7 +450,7 @@ void main() {
       expect(item2, expectedItem2);
     });
 
-    test('additionalProperties entity that should not parse to object test',
+    test('additionalProperties entity that should not parse to object test 3.0',
         () async {
       final schemaPath = p.join(
         'test',
@@ -507,6 +507,60 @@ void main() {
       }
       expect(item2, expectedItem2);
     });
+
+    test('additionalProperties entity should parse to object test 2.0',
+            () async {
+          final schemaPath = p.join(
+            'test',
+            'parser',
+            'schemas',
+            'additional_properties_class.2.0.json',
+          );
+          final configFile = schemaFile(schemaPath);
+          final schemaContent = configFile!.readAsStringSync();
+          final parser = OpenApiParser(schemaContent);
+          final dataClasses = parser.parseDataClasses().toList();
+          final expectedDataClasses = <UniversalDataClass>[
+            const UniversalComponentClass(
+              name: 'ValueClass',
+              imports: {},
+              parameters: [
+                UniversalType(
+                  type: 'string',
+                  name: 'testProp',
+                  jsonKey: 'testProp',
+                  description: 'A test property',
+                ),
+              ],
+            ),
+            const UniversalComponentClass(
+              name: 'WrapperClass',
+              imports: { 'ValueClass' },
+              parameters: [
+                UniversalType(
+                  type: 'ValueClass',
+                  name: 'map',
+                  jsonKey: 'map',
+                  mapType: 'string',
+                ),
+              ],
+            ),
+          ];
+
+          expect(dataClasses.length, expectedDataClasses.length);
+          final item1 = dataClasses[0] as UniversalComponentClass;
+          final item2 = dataClasses[1] as UniversalComponentClass;
+          final expectedItem1 = expectedDataClasses[0] as UniversalComponentClass;
+          final expectedItem2 = expectedDataClasses[1] as UniversalComponentClass;
+          expect(item1.parameters.length, expectedItem1.parameters.length);
+          for (var i = 0; i < item1.parameters.length; i++) {
+            expect(
+              item1.parameters[i],
+              expectedItem1.parameters[i],
+            );
+          }
+          expect(item2, expectedItem2);
+        });
 
     test('Enum name test', () async {
       final schemaPath = p.join('test', 'parser', 'schemas', 'enum_class.json');

--- a/swagger_parser/test/parser/data_classes_test.dart
+++ b/swagger_parser/test/parser/data_classes_test.dart
@@ -487,6 +487,7 @@ void main() {
               description: 'data',
               jsonKey: 'data',
               isRequired: false,
+              mapType: 'string',
             ),
           ],
         ),

--- a/swagger_parser/test/parser/schemas/additional_properties_class.2.0.json
+++ b/swagger_parser/test/parser/schemas/additional_properties_class.2.0.json
@@ -1,0 +1,76 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "API",
+    "version": "1.0",
+    "title": "REST API"
+  },
+  "host": "localhost:8081",
+  "basePath": "/",
+  "tags": [
+    {
+      "name": "Test",
+      "description": "Test"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "operationId": "testMethod",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/WrapperClass"
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "ValueClass": {
+      "type": "object",
+      "required": [
+        "testProp"
+      ],
+      "properties": {
+        "testProp": {
+          "type": "string",
+          "description": "A test property"
+        }
+      },
+      "title": "ValueClass"
+    },
+    "WrapperClass": {
+      "type": "object",
+      "required": [
+        "map"
+      ],
+      "properties": {
+        "map": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ValueClass"
+          }
+        }
+      },
+      "title": "WrapperClass"
+    }
+  }
+}


### PR DESCRIPTION
This pull request solves an issue with generating maps. I have this json swagger v2: [restapi.json](https://github.com/Carapacik/swagger_parser/files/13887916/restapi.json) which has a `WrapperClass`. As a property `WrapperClass` has a `Map<String, ValueClass>`, which is defined with [this syntax](https://swagger.io/docs/specification/data-models/dictionaries/). What was previosly generated was:

```dart
@JsonSerializable()
class WrapperClass {
  const WrapperClass({
    required this.map,
  });
  
  factory WrapperClass.fromJson(Map<String, Object?> json) => _$WrapperClassFromJson(json);
  
  final ValueClass map;

  Map<String, Object?> toJson() => _$WrapperClassToJson(this);
}
```

while the correct generated code is

```dart
@JsonSerializable()
class WrapperClass {
  const WrapperClass({
    required this.map,
  });
  
  factory WrapperClass.fromJson(Map<String, Object?> json) => _$WrapperClassFromJson(json);
  
  final Map<String, ValueClass> map;

  Map<String, Object?> toJson() => _$WrapperClassToJson(this);
}

```
