### PR TITLE
Use an object correctly even if empty

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -639,8 +639,10 @@ class OpenApiParser {
         );
       }
 
-      if (value.containsKey(_propertiesConst)) {
-        findParametersAndImports(value);
+      if (value[_typeConst] == _objectConst) {
+        if (value.containsKey(_propertiesConst)) {
+          findParametersAndImports(value);
+        }        
       } else if (value.containsKey(_enumConst)) {
         final items = protectEnumItemsNames(
           (value[_enumConst] as List).map((e) => '$e'),

--- a/swagger_parser/test/parser/data_classes_test.dart
+++ b/swagger_parser/test/parser/data_classes_test.dart
@@ -36,6 +36,24 @@ void main() {
     });
   });
 
+  group('Empty object class', () {
+    test('3.0', () async {
+      final schemaPath =
+          p.join('test', 'parser', 'schema', 'empty_object.3.0.json');
+      final configFile = schemaFile(schemaPath);
+      final schemaContent = configFile!.readAsStringSync();
+      final parser = OpenApiParser(ParserConfig(schemaContent, isJson: true));
+      final actualDataClass = parser.parseDataClasses().first;
+      const expectedDataClass = UniversalComponentClass(
+        name: 'ClassName',
+        imports: {},
+        parameters: [],
+        typeDef: false
+      );
+      expect(actualDataClass, expectedDataClass);
+    });
+  });
+
   group('Types check', () {
     test('basic types check 2.0', () async {
       final schemaPath =

--- a/swagger_parser/test/parser/schema/empty_object.3.0.json
+++ b/swagger_parser/test/parser/schema/empty_object.3.0.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.0.0",
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ClassName": {
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix the error Null check operator used on a null value when run retrofit https://github.com/Carapacik/swagger_parser/issues/110#issuecomment-1968696030 when the object has no parameters
            