### PR TITLE
Multi Fix

### DIFF
--- a/swagger_parser/lib/src/parser/model/universal_request_type.dart
+++ b/swagger_parser/lib/src/parser/model/universal_request_type.dart
@@ -59,6 +59,8 @@ enum HttpParameterType {
 
   /// `@Part`
   part('Part'),
+  //
+  cookie('Cookie'),
 
   /// `@Part`
   formData('Part');

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -72,6 +72,7 @@ class OpenApiParser {
   static const _propertiesConst = 'properties';
   static const _refConst = r'$ref';
   static const _requestBodyConst = 'requestBody';
+  static const _requestBodiesConst = 'requestBodies';
   static const _requiredConst = 'required';
   static const _responsesConst = 'responses';
   static const _schemaConst = 'schema';
@@ -259,7 +260,32 @@ class OpenApiParser {
         }
       }
       if (map.containsKey(_requestBodyConst)) {
-        final requestBody = map[_requestBodyConst] as Map<String, dynamic>;
+        var requestBody = map[_requestBodyConst] as Map<String, dynamic>;
+
+        final isRefBody = requestBody.containsKey(_refConst);
+
+        if (isRefBody) {
+          final refBodyName = _formatRef(requestBody);
+
+          final isRefBodyExist = _definitionFileContent
+                  .containsKey(_componentsConst) &&
+              (_definitionFileContent[_componentsConst] as Map<String, dynamic>)
+                  .containsKey(_requestBodiesConst) &&
+              ((_definitionFileContent[_componentsConst]
+                          as Map<String, dynamic>)[_requestBodiesConst]
+                      as Map<String, dynamic>)
+                  .containsKey(refBodyName);
+
+          if (!isRefBodyExist) {
+            throw OpenApiParserException(
+              '${requestBody[_refConst]} does not exist in schema',
+            );
+          }
+          requestBody = ((_definitionFileContent[_componentsConst]
+                  as Map<String, dynamic>)[_requestBodiesConst]
+              as Map<String, dynamic>)[refBodyName] as Map<String, dynamic>;
+        }
+
         if (!requestBody.containsKey(_contentConst)) {
           throw const OpenApiParserException(
             'Request body must always have content.',

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 import '../../utils/case_utils.dart';
+import '../../utils/output/io_output.dart';
 import '../../utils/type_utils.dart';
 import '../config/parser_config.dart';
 import '../exception/open_api_parser_exception.dart';
@@ -247,16 +248,21 @@ class OpenApiParser {
           final parameterType = HttpParameterType.values.firstWhere(
             (e) => e.name == (parameter[_inConst].toString()),
           );
-          types.add(
-            UniversalRequestType(
-              parameterType: parameterType,
-              type: typeWithImport.type,
-              description: parameter[_descriptionConst]?.toString(),
-              name: parameterType.isBody && parameter[_nameConst] == _bodyConst
-                  ? null
-                  : parameter[_nameConst].toString(),
-            ),
-          );
+          if (parameterType == HttpParameterType.cookie) {
+            cookieWarnMessage();
+          } else {
+            types.add(
+              UniversalRequestType(
+                parameterType: parameterType,
+                type: typeWithImport.type,
+                description: parameter[_descriptionConst]?.toString(),
+                name:
+                    parameterType.isBody && parameter[_nameConst] == _bodyConst
+                        ? null
+                        : parameter[_nameConst].toString(),
+              ),
+            );
+          }
         }
       }
       if (map.containsKey(_requestBodyConst)) {
@@ -504,16 +510,20 @@ class OpenApiParser {
         final parameterType = HttpParameterType.values.firstWhere(
           (e) => e.name == (parameter[_inConst].toString()),
         );
-        types.add(
-          UniversalRequestType(
-            parameterType: parameterType,
-            type: typeWithImport.type,
-            description: parameter[_descriptionConst]?.toString(),
-            name: parameterType.isBody && parameter[_nameConst] == _bodyConst
-                ? null
-                : parameter[_nameConst].toString(),
-          ),
-        );
+        if (parameterType == HttpParameterType.cookie) {
+          cookieWarnMessage();
+        } else {
+          types.add(
+            UniversalRequestType(
+              parameterType: parameterType,
+              type: typeWithImport.type,
+              description: parameter[_descriptionConst]?.toString(),
+              name: parameterType.isBody && parameter[_nameConst] == _bodyConst
+                  ? null
+                  : parameter[_nameConst].toString(),
+            ),
+          );
+        }
       }
       return types;
     }

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -72,7 +72,6 @@ class OpenApiParser {
   static const _propertiesConst = 'properties';
   static const _refConst = r'$ref';
   static const _requestBodyConst = 'requestBody';
-  static const _requestBodiesConst = 'requestBodies';
   static const _requiredConst = 'required';
   static const _responsesConst = 'responses';
   static const _schemaConst = 'schema';
@@ -260,32 +259,7 @@ class OpenApiParser {
         }
       }
       if (map.containsKey(_requestBodyConst)) {
-        var requestBody = map[_requestBodyConst] as Map<String, dynamic>;
-
-        final isRefBody = requestBody.containsKey(_refConst);
-
-        if (isRefBody) {
-          final refBodyName = _formatRef(requestBody);
-
-          final isRefBodyExist = _definitionFileContent
-                  .containsKey(_componentsConst) &&
-              (_definitionFileContent[_componentsConst] as Map<String, dynamic>)
-                  .containsKey(_requestBodiesConst) &&
-              ((_definitionFileContent[_componentsConst]
-                          as Map<String, dynamic>)[_requestBodiesConst]
-                      as Map<String, dynamic>)
-                  .containsKey(refBodyName);
-
-          if (!isRefBodyExist) {
-            throw OpenApiParserException(
-              '${requestBody[_refConst]} does not exist in schema',
-            );
-          }
-          requestBody = ((_definitionFileContent[_componentsConst]
-                  as Map<String, dynamic>)[_requestBodiesConst]
-              as Map<String, dynamic>)[refBodyName] as Map<String, dynamic>;
-        }
-
+        final requestBody = map[_requestBodyConst] as Map<String, dynamic>;
         if (!requestBody.containsKey(_contentConst)) {
           throw const OpenApiParserException(
             'Request body must always have content.',

--- a/swagger_parser/lib/src/utils/output/io_output.dart
+++ b/swagger_parser/lib/src/utils/output/io_output.dart
@@ -24,6 +24,11 @@ void generateMessage() {
   stdout.writeln('Generate...');
 }
 
+void cookieWarnMessage() {
+  stdout.writeln(
+      '${_red}Warning: Cookie parameters are not supported by this generator, they will be ignored$_reset');
+}
+
 void successMessage({
   required int successSchemasCount,
   required int schemesCount,


### PR DESCRIPTION
These bugs came up during testing:

1) Pull parameters from ref on V2 and V3
<details><summary>Fixes Schema Example</summary>
<p>

```
openapi: 3.0.0
servers:
  - url: 'http://petstore.swagger.io/v2'
info:
  description: >-
    This is a sample server Petstore server. For this sample, you can use the api key
    `special-key` to test the authorization filters.
  version: 1.0.0
  title: OpenAPI Petstore
  license:
    name: Apache-2.0
    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
tags:
  - name: pet
    description: Everything about your Pets
paths:
  /pet:
    post:
      tags:
        - pet
      summary: Add a new pet to the store
      description: ''
      operationId: addPet
      responses:
        '200':
          description: successful operation
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Pet'
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
        '405':
          description: Invalid input
      security:
        - http_basic: []
      requestBody:
        $ref: '#/components/requestBodies/Pet'

externalDocs:
  description: Find out more about Swagger
  url: 'http://swagger.io'
components:
  securitySchemes:
    http_basic:
      type: http
      scheme: basic
  requestBodies:
    Pet:
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Pet'
        application/xml:
          schema:
            $ref: '#/components/schemas/Pet'
      description: Pet object that needs to be added to the store
      required: true
  schemas:
    Category:
      title: Pet category
      description: A category for a pet
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
      xml:
        name: Category
    Tag:
      title: Pet Tag
      description: A tag for a pet
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
      xml:
        name: Tag
    Pet:
      title: a Pet
      description: A pet for sale in the pet store
      type: object
      required:
        - name
        - photoUrls
      properties:
        id:
          type: integer
          format: int64
        category:
          $ref: '#/components/schemas/Category'
        name:
          type: string
          example: doggie
        photoUrls:
          type: array
          xml:
            name: photoUrl
            wrapped: true
          items:
            type: string
        tags:
          type: array
          xml:
            name: tag
            wrapped: true
          items:
            $ref: '#/components/schemas/Tag'
        status:
          type: string
          description: pet status in the store
          deprecated: true
          enum:
            - available
            - pending
            - sold
      xml:
        name: Pet
```

</p>
</details> 

2) Don't rename to pascal case when pulling request name from component

<details><summary>Fixes Schema Example</summary>
<p>

```
openapi: 3.0.0
info:
  description: This is a sample server Petstore server. For this sample, you can use
    the api key `special-key` to test the authorization filters.
  license:
    name: Apache-2.0
    url: https://www.apache.org/licenses/LICENSE-2.0.html
  title: OpenAPI Petstore
  version: 1.0.0
externalDocs:
  description: Find out more about Swagger
  url: http://swagger.io
servers:
- url: http://petstore.swagger.io/v2
tags:
- description: Everything about your Pets
  name: pet
- description: Access to Petstore orders
  name: store
- description: Operations about user
  name: user
paths:
  /pet:
    post:
      operationId: addPet
      requestBody:
        $ref: '#/components/requestBodies/Pet'
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Pet'
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
          description: successful operation
        "405":
          description: Invalid input
      security:
      - petstore_auth:
        - write:pets
        - read:pets
      summary: Add a new pet to the store
      tags:
      - pet
    put:
      operationId: updatePet
      requestBody:
        $ref: '#/components/requestBodies/Pet'
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Pet'
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
          description: successful operation
        "400":
          description: Invalid ID supplied
        "404":
          description: Pet not found
        "405":
          description: Validation exception
      security:
      - petstore_auth:
        - write:pets
        - read:pets
      summary: Update an existing pet
      tags:
      - pet
  /pet/findByStatus:
    get:
      description: Multiple status values can be provided with comma separated strings
      operationId: findPetsByStatus
      parameters:
      - description: Status values that need to be considered for filter
        explode: false
        in: query
        name: status
        required: true
        schema:
          items:
            default: available
            enum:
            - available
            - pending
            - sold
            type: string
          type: array
        style: form
      responses:
        "200":
          content:
            application/xml:
              schema:
                items:
                  $ref: '#/components/schemas/Pet'
                type: array
            application/json:
              schema:
                items:
                  $ref: '#/components/schemas/Pet'
                type: array
          description: successful operation
        "400":
          description: Invalid status value
      security:
      - petstore_auth:
        - read:pets
      summary: Finds Pets by status
      tags:
      - pet
  /pet/findByTags:
    get:
      deprecated: true
      description: Multiple tags can be provided with comma separated strings. Use
        tag1, tag2, tag3 for testing.
      operationId: findPetsByTags
      parameters:
      - description: Tags to filter by
        explode: false
        in: query
        name: tags
        required: true
        schema:
          items:
            type: string
          type: array
        style: form
      responses:
        "200":
          content:
            application/xml:
              schema:
                items:
                  $ref: '#/components/schemas/Pet'
                type: array
            application/json:
              schema:
                items:
                  $ref: '#/components/schemas/Pet'
                type: array
          description: successful operation
        "400":
          description: Invalid tag value
      security:
      - petstore_auth:
        - read:pets
      summary: Finds Pets by tags
      tags:
      - pet
  /pet/{petId}:
    delete:
      operationId: deletePet
      parameters:
      - explode: false
        in: header
        name: api_key
        required: false
        schema:
          type: string
        style: simple
      - description: Pet id to delete
        explode: false
        in: path
        name: petId
        required: true
        schema:
          format: int64
          type: integer
        style: simple
      responses:
        "400":
          description: Invalid pet value
      security:
      - petstore_auth:
        - write:pets
        - read:pets
      summary: Deletes a pet
      tags:
      - pet
    get:
      description: Returns a single pet
      operationId: getPetById
      parameters:
      - description: ID of pet to return
        explode: false
        in: path
        name: petId
        required: true
        schema:
          format: int64
          type: integer
        style: simple
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Pet'
            application/json:
              schema:
                $ref: '#/components/schemas/Pet'
          description: successful operation
        "400":
          description: Invalid ID supplied
        "404":
          description: Pet not found
      security:
      - api_key: []
      summary: Find pet by ID
      tags:
      - pet
    post:
      operationId: updatePetWithForm
      parameters:
      - description: ID of pet that needs to be updated
        explode: false
        in: path
        name: petId
        required: true
        schema:
          format: int64
          type: integer
        style: simple
      requestBody:
        $ref: '#/components/requestBodies/inline_object'
        content:
          application/x-www-form-urlencoded:
            schema:
              properties:
                name:
                  description: Updated name of the pet
                  type: string
                status:
                  description: Updated status of the pet
                  type: string
              type: object
      responses:
        "405":
          description: Invalid input
      security:
      - petstore_auth:
        - write:pets
        - read:pets
      summary: Updates a pet in the store with form data
      tags:
      - pet
  /pet/{petId}/uploadImage:
    post:
      operationId: uploadFile
      parameters:
      - description: ID of pet to update
        explode: false
        in: path
        name: petId
        required: true
        schema:
          format: int64
          type: integer
        style: simple
      requestBody:
        $ref: '#/components/requestBodies/inline_object_1'
        content:
          multipart/form-data:
            schema:
              properties:
                additionalMetadata:
                  description: Additional data to pass to server
                  type: string
                file:
                  description: file to upload
                  format: binary
                  type: string
              type: object
      responses:
        "200":
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ApiResponse'
          description: successful operation
      security:
      - petstore_auth:
        - write:pets
        - read:pets
      summary: uploads an image
      tags:
      - pet
  /store/inventory:
    get:
      description: Returns a map of status codes to quantities
      operationId: getInventory
      responses:
        "200":
          content:
            application/json:
              schema:
                additionalProperties:
                  format: int32
                  type: integer
                type: object
          description: successful operation
      security:
      - api_key: []
      summary: Returns pet inventories by status
      tags:
      - store
  /store/order:
    post:
      operationId: placeOrder
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Order'
        description: order placed for purchasing the pet
        required: true
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Order'
            application/json:
              schema:
                $ref: '#/components/schemas/Order'
          description: successful operation
        "400":
          description: Invalid Order
      summary: Place an order for a pet
      tags:
      - store
  /store/order/{orderId}:
    delete:
      description: For valid response try integer IDs with value < 1000. Anything
        above 1000 or nonintegers will generate API errors
      operationId: deleteOrder
      parameters:
      - description: ID of the order that needs to be deleted
        explode: false
        in: path
        name: orderId
        required: true
        schema:
          type: string
        style: simple
      responses:
        "400":
          description: Invalid ID supplied
        "404":
          description: Order not found
      summary: Delete purchase order by ID
      tags:
      - store
    get:
      description: For valid response try integer IDs with value <= 5 or > 10. Other
        values will generate exceptions
      operationId: getOrderById
      parameters:
      - description: ID of pet that needs to be fetched
        explode: false
        in: path
        name: orderId
        required: true
        schema:
          format: int64
          maximum: 5
          minimum: 1
          type: integer
        style: simple
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/Order'
            application/json:
              schema:
                $ref: '#/components/schemas/Order'
          description: successful operation
        "400":
          description: Invalid ID supplied
        "404":
          description: Order not found
      summary: Find purchase order by ID
      tags:
      - store
  /user:
    post:
      description: This can only be done by the logged in user.
      operationId: createUser
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/User'
        description: Created user object
        required: true
      responses:
        default:
          description: successful operation
      security:
      - api_key: []
      summary: Create user
      tags:
      - user
  /user/createWithArray:
    post:
      operationId: createUsersWithArrayInput
      requestBody:
        $ref: '#/components/requestBodies/UserArray'
      responses:
        default:
          description: successful operation
      security:
      - api_key: []
      summary: Creates list of users with given input array
      tags:
      - user
  /user/createWithList:
    post:
      operationId: createUsersWithListInput
      requestBody:
        $ref: '#/components/requestBodies/UserArray'
      responses:
        default:
          description: successful operation
      security:
      - api_key: []
      summary: Creates list of users with given input array
      tags:
      - user
  /user/login:
    get:
      operationId: loginUser
      parameters:
      - description: The user name for login
        explode: true
        in: query
        name: username
        required: true
        schema:
          pattern: ^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$
          type: string
        style: form
      - description: The password for login in clear text
        explode: true
        in: query
        name: password
        required: true
        schema:
          type: string
        style: form
      responses:
        "200":
          content:
            application/xml:
              schema:
                type: string
            application/json:
              schema:
                type: string
          description: successful operation
          headers:
            Set-Cookie:
              description: Cookie authentication key for use with the `api_key` apiKey
                authentication.
              explode: false
              schema:
                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
                type: string
              style: simple
            X-Rate-Limit:
              description: calls per hour allowed by the user
              explode: false
              schema:
                format: int32
                type: integer
              style: simple
            X-Expires-After:
              description: date in UTC when token expires
              explode: false
              schema:
                format: date-time
                type: string
              style: simple
        "400":
          description: Invalid username/password supplied
      summary: Logs user into the system
      tags:
      - user
  /user/logout:
    get:
      operationId: logoutUser
      responses:
        default:
          description: successful operation
      security:
      - api_key: []
      summary: Logs out current logged in user session
      tags:
      - user
  /user/{username}:
    delete:
      description: This can only be done by the logged in user.
      operationId: deleteUser
      parameters:
      - description: The name that needs to be deleted
        explode: false
        in: path
        name: username
        required: true
        schema:
          type: string
        style: simple
      responses:
        "400":
          description: Invalid username supplied
        "404":
          description: User not found
      security:
      - api_key: []
      summary: Delete user
      tags:
      - user
    get:
      operationId: getUserByName
      parameters:
      - description: The name that needs to be fetched. Use user1 for testing.
        explode: false
        in: path
        name: username
        required: true
        schema:
          type: string
        style: simple
      responses:
        "200":
          content:
            application/xml:
              schema:
                $ref: '#/components/schemas/User'
            application/json:
              schema:
                $ref: '#/components/schemas/User'
          description: successful operation
        "400":
          description: Invalid username supplied
        "404":
          description: User not found
      summary: Get user by user name
      tags:
      - user
    put:
      description: This can only be done by the logged in user.
      operationId: updateUser
      parameters:
      - description: name that need to be deleted
        explode: false
        in: path
        name: username
        required: true
        schema:
          type: string
        style: simple
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/User'
        description: Updated user object
        required: true
      responses:
        "400":
          description: Invalid user supplied
        "404":
          description: User not found
      security:
      - api_key: []
      summary: Updated user
      tags:
      - user
components:
  requestBodies:
    UserArray:
      content:
        application/json:
          schema:
            items:
              $ref: '#/components/schemas/User'
            type: array
      description: List of user object
      required: true
    Pet:
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/Pet'
        application/xml:
          schema:
            $ref: '#/components/schemas/Pet'
      description: Pet object that needs to be added to the store
      required: true
    inline_object:
      content:
        application/x-www-form-urlencoded:
          schema:
            $ref: '#/components/schemas/inline_object'
    inline_object_1:
      content:
        multipart/form-data:
          schema:
            $ref: '#/components/schemas/inline_object_1'
  schemas:
    Order:
      description: An order for a pets from the pet store
      example:
        petId: 6
        quantity: 1
        id: 0
        shipDate: 2000-01-23T04:56:07.000+00:00
        complete: false
        status: placed
      properties:
        id:
          format: int64
          type: integer
        petId:
          format: int64
          type: integer
        quantity:
          format: int32
          type: integer
        shipDate:
          format: date-time
          type: string
        status:
          description: Order Status
          enum:
          - placed
          - approved
          - delivered
          type: string
        complete:
          default: false
          type: boolean
      title: Pet Order
      type: object
      xml:
        name: Order
    Category:
      description: A category for a pet
      example:
        name: name
        id: 6
      properties:
        id:
          format: int64
          type: integer
        name:
          pattern: ^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$
          type: string
      title: Pet category
      type: object
      xml:
        name: Category
    User:
      description: A User who is purchasing from the pet store
      example:
        firstName: firstName
        lastName: lastName
        password: password
        userStatus: 6
        phone: phone
        id: 0
        email: email
        username: username
      properties:
        id:
          format: int64
          type: integer
        username:
          type: string
        firstName:
          type: string
        lastName:
          type: string
        email:
          type: string
        password:
          type: string
        phone:
          type: string
        userStatus:
          description: User Status
          format: int32
          type: integer
      title: a User
      type: object
      xml:
        name: User
    Tag:
      description: A tag for a pet
      example:
        name: name
        id: 1
      properties:
        id:
          format: int64
          type: integer
        name:
          type: string
      title: Pet Tag
      type: object
      xml:
        name: Tag
    Pet:
      description: A pet for sale in the pet store
      example:
        photoUrls:
        - photoUrls
        - photoUrls
        name: doggie
        id: 0
        category:
          name: name
          id: 6
        tags:
        - name: name
          id: 1
        - name: name
          id: 1
        status: available
      properties:
        id:
          format: int64
          type: integer
        category:
          $ref: '#/components/schemas/Category'
        name:
          example: doggie
          type: string
        photoUrls:
          items:
            type: string
          type: array
          xml:
            name: photoUrl
            wrapped: true
        tags:
          items:
            $ref: '#/components/schemas/Tag'
          type: array
          xml:
            name: tag
            wrapped: true
        status:
          description: pet status in the store
          enum:
          - available
          - pending
          - sold
          type: string
      required:
      - name
      - photoUrls
      title: a Pet
      type: object
      xml:
        name: Pet
    ApiResponse:
      description: Describes the result of uploading an image resource
      example:
        code: 0
        type: type
        message: message
      properties:
        code:
          format: int32
          type: integer
        type:
          type: string
        message:
          type: string
      title: An uploaded response
      type: object
    inline_object:
      properties:
        name:
          description: Updated name of the pet
          type: string
        status:
          description: Updated status of the pet
          type: string
      type: object
    inline_object_1:
      properties:
        additionalMetadata:
          description: Additional data to pass to server
          type: string
        file:
          description: file to upload
          format: binary
          type: string
      type: object
  securitySchemes:
    petstore_auth:
      flows:
        implicit:
          authorizationUrl: http://petstore.swagger.io/api/oauth/dialog
          scopes:
            write:pets: modify pets in your account
            read:pets: read your pets
      type: oauth2
    api_key:
      in: header
      name: api_key
      type: apiKey

```

</p>
</details> 

3) Ignore methods that start with `x-`
<details><summary>Fixes Schema Example</summary>
<p>

```
openapi: 3.0.1
info:
  version: 1.0.0
  title: Example
  license:
    name: MIT
servers:
  - url: http://api.example.xyz/v1
paths:
  /deprecated-test:
    x-swagger-router-controller: /deprecated-test
    post:
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Non.Stripped.Request'
      responses:
        '200':
          description: responses
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Response'
components:
  schemas:
    Non.Stripped.Request:
      type: object
      properties:
        customerCode:
          type: string
          example: '0001'
        firstName:
          type: string
          deprecated: true
          example: 'first'
    Response:
      type: object
      properties:
        customerCode:
          type: string
          example: '0001'
        firstName:
          type: string
          deprecated: true
          example: 'first'
```


</p>
</details> 

4) Using a cookie parameter

<details><summary>Fixes Schema Example</summary>
<p>

```
openapi: 3.0.0
info:
  version: 1.0.0
  title: OpenAPI Petstore
paths:
  /pet/{id}:
    post:
      operationId: create
      parameters:
        - in: path
          name: id
          required: true
          schema:
            type: integer
            format: int32
        - in: header
          name: id
          schema:
            type: integer
            format: int32
        - in: cookie
          name: id
          schema:
            type: integer
            format: int32
        - in: query
          name: id
          schema:
            type: integer
            format: int32
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                id:
                  type: integer
                  format: int32
                pathid:
                  type: integer
                  format: int32
                headerId2:
                  type: integer
                  format: int32
                cookieId2:
                  type: integer
                  format: int32
                queryId2:
                  type: integer
                  format: int32
      responses:
        '400':
          description: Invalid pet value
```

</p>
</details> 


Fixes:
https://github.com/Carapacik/swagger_parser/issues/187
https://github.com/Carapacik/swagger_parser/issues/186
https://github.com/Carapacik/swagger_parser/issues/185
https://github.com/Carapacik/swagger_parser/issues/183