### PR TITLE
Allow variables to contain dash without renaming

### DIFF
--- a/swagger_parser/lib/src/parser/utils/type_utils.dart
+++ b/swagger_parser/lib/src/parser/utils/type_utils.dart
@@ -175,7 +175,7 @@ Set<UniversalEnumItem> protectEnumItemsNames(Iterable<String> names) {
   return items;
 }
 
-final _nameRegExp = RegExp(r'^[a-zA-Z_][a-zA-Z\d_]*$');
+final _nameRegExp = RegExp(r'^[a-zA-Z_-][a-zA-Z\d_-]*$');
 
 /// Protect name from incorrect symbols, keywords, etc.
 (String? newName, String? description) protectName(


### PR DESCRIPTION
No longer will rename variables containing dash to object[number] name