### PR TITLE
fix: Handle Empty Enum Value Case

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -98,9 +98,16 @@ String _enumValue(
   required bool jsonParam,
 }) {
   final protectedJsonKey = protectJsonKey(item.jsonKey);
+  final value = type == 'string'
+      ? "'$protectedJsonKey'"
+      : protectedJsonKey?.isEmpty ?? true
+          ? "''"
+          : protectedJsonKey;
+
+  final name = item.name.isEmpty ? 'empty' : item.name;
   return '''
-${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue(${type == 'string' ? "'$protectedJsonKey'" : protectedJsonKey})
-  ${item.name.toCamel}${jsonParam ? '(${type == 'string' ? "'$protectedJsonKey'" : protectedJsonKey})' : ''}''';
+${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}  @JsonValue($value)
+  ${name.toCamel}${jsonParam ? '($value)' : ''}''';
 }
 
 String _enumValueDartMappable(


### PR DESCRIPTION
## Problem

If we have a such enum:
```yaml
    BlankEnum:
      enum:
      - ''
```
we'll get this:
```dart
// coverage:ignore-file
// GENERATED CODE - DO NOT MODIFY BY HAND
// ignore_for_file: type=lint, unused_import

import 'package:json_annotation/json_annotation.dart';

@JsonEnum()
enum BlankEnum {
  @JsonValue()
  (),
  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
  $unknown(null);

  const BlankEnum(this.json);

  factory BlankEnum.fromJson(dynamic json) => values.firstWhere(
        (e) => e.json == json,
        orElse: () => $unknown,
      );

  final dynamic? json;
}
```

## Solution

If value of enum is empty string, we just use `empty` as its name:
```dart
// coverage:ignore-file
// GENERATED CODE - DO NOT MODIFY BY HAND
// ignore_for_file: type=lint, unused_import

import 'package:json_annotation/json_annotation.dart';

@JsonEnum()
enum BlankEnum {
  @JsonValue('')
  empty(''),
  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
  $unknown(null);

  const BlankEnum(this.json);

  factory BlankEnum.fromJson(dynamic json) => values.firstWhere(
        (e) => e.json == json,
        orElse: () => $unknown,
      );

  final dynamic? json;
}
```

