### PR TITLE
fix same poperty name confliction

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
@@ -39,6 +40,7 @@ class OpenApiParser {
   final _enumClasses = <UniversalEnumClass>{};
   final _usedNamesCount = <String, int>{};
   final _skipDataClasses = <String>[];
+  final _objectNamesCount = <String, int>{};
 
   static const _additionalPropertiesConst = 'additionalProperties';
   static const _allOfConst = 'allOf';
@@ -1020,6 +1022,15 @@ class OpenApiParser {
 
       for (final replacementRule in config.replacementRules) {
         type = replacementRule.apply(type)!;
+      }
+
+      // Check for duplicate type names
+      if (_objectNamesCount.containsKey(type)) {
+        _objectNamesCount[type] = _objectNamesCount[type]! + 1;
+        type = '$type${_objectNamesCount[type]}';
+        stdout.writeln('Found duplicate object name: $type');
+      } else {
+        _objectNamesCount[type] = 1;
       }
 
       if (_objectClasses.where((oc) => oc.name == type).isEmpty) {


### PR DESCRIPTION
## Issue Description
I addresses the issue [#235](https://github.com/Carapacik/swagger_parser/issues/235) where model file names conflict if different paths use the same property key.

## Expected Results
The generated code should distinguish between the data properties of /foo and /bar responses.

## Actual Results
Only one Data model is created for both responses.

## What I Changed
Modified the open_api_parser.dart file to increment object names when duplicate type names are found.
Added a check for duplicate type names and incremented the object name if a duplicate is detected.

Thank you for considering this PR. 
I look forward to your feedback!

Thank you.