### PR TITLE
Add includeIfNull configuration option

### DIFF
--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -128,6 +128,9 @@ swagger_parser:
   # Optional (dart only). Set 'true' to wrap all request return types with HttpResponse.
   original_http_response: false
 
+  # Optional (dart only) Set 'false' to exclude null fields from json
+  include_if_null: true
+
   # Optional. Set regex replacement rules for the names of the generated classes/enums.
   # All rules are applied in order.
   replacement_rules:

--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -32,6 +32,7 @@ class SWPConfig {
     this.mergeClients = false,
     this.enumsParentPrefix = true,
     this.skippedParameters = const <String>[],
+    this.includeIfNull = true,
   });
 
   /// Internal constructor of [SWPConfig]
@@ -58,6 +59,7 @@ class SWPConfig {
     required this.mergeClients,
     required this.enumsParentPrefix,
     required this.skippedParameters,
+    required this.includeIfNull,
   });
 
   /// Creates a [SWPConfig] from [YamlMap].
@@ -273,6 +275,13 @@ class SWPConfig {
       }
     }
 
+    final includeIfNull = yamlMap['include_if_null'];
+    if (includeIfNull is! bool?) {
+      throw const ConfigException(
+        "Config parameter 'includeIfNull' must be bool.",
+      );
+    }
+
     // Default config
     final dc = SWPConfig(name: name, outputDirectory: outputDirectory);
 
@@ -300,6 +309,7 @@ class SWPConfig {
       markFilesAsGenerated: markFilesAsGenerated ?? dc.markFilesAsGenerated,
       originalHttpResponse: originalHttpResponse ?? dc.originalHttpResponse,
       replacementRules: replacementRules ?? dc.replacementRules,
+      includeIfNull: includeIfNull ?? dc.includeIfNull,
     );
   }
 
@@ -393,6 +403,10 @@ class SWPConfig {
   /// List of parameter names that should skip during parsing
   final List<String> skippedParameters;
 
+  /// DART ONLY
+  /// Optional. Set `false` to not include if field is null.
+  final bool includeIfNull;
+
   /// Convert [SWPConfig] to [GeneratorConfig]
   GeneratorConfig toGeneratorConfig() {
     return GeneratorConfig(
@@ -412,6 +426,7 @@ class SWPConfig {
       markFilesAsGenerated: markFilesAsGenerated,
       originalHttpResponse: originalHttpResponse,
       replacementRules: replacementRules,
+      includeIfNull: includeIfNull,
     );
   }
 

--- a/swagger_parser/lib/src/generator/config/generator_config.dart
+++ b/swagger_parser/lib/src/generator/config/generator_config.dart
@@ -21,6 +21,7 @@ class GeneratorConfig {
     this.unknownEnumValue = true,
     this.markFilesAsGenerated = false,
     this.originalHttpResponse = false,
+    this.includeIfNull = true,
     this.replacementRules = const [],
   });
 
@@ -80,6 +81,10 @@ class GeneratorConfig {
   /// If the content type does not match the default, generates:
   /// `@Headers(<String, String>{'Content-Type': 'PARSED CONTENT TYPE'})`
   final String defaultContentType;
+
+  /// DART ONLY
+  /// Optional. Set `false` to not include if null.
+  final bool includeIfNull;
 
   /// DART ONLY
   /// Add extra parameter to all requests. Supported after retrofit 4.1.0.

--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -29,6 +29,7 @@ final class FillController {
           enumsToJson: config.enumsToJson,
           unknownEnumValue: config.unknownEnumValue,
           markFilesAsGenerated: config.markFilesAsGenerated,
+          includeIfNull: config.includeIfNull,
         ),
       );
 

--- a/swagger_parser/lib/src/generator/model/programming_language.dart
+++ b/swagger_parser/lib/src/generator/model/programming_language.dart
@@ -44,6 +44,7 @@ enum ProgrammingLanguage {
     required bool enumsToJson,
     required bool unknownEnumValue,
     required bool markFilesAsGenerated,
+    required bool includeIfNull,
   }) {
     switch (this) {
       case dart:
@@ -68,16 +69,19 @@ enum ProgrammingLanguage {
               return dartFreezedDtoTemplate(
                 dataClass,
                 markFileAsGenerated: markFilesAsGenerated,
+                includeIfNull: includeIfNull,
               );
             case JsonSerializer.jsonSerializable:
               return dartJsonSerializableDtoTemplate(
                 dataClass,
                 markFileAsGenerated: markFilesAsGenerated,
+                includeIfNull: includeIfNull,
               );
             case JsonSerializer.dartMappable:
               return dartDartMappableDtoTemplate(
                 dataClass,
                 markFileAsGenerated: markFilesAsGenerated,
+                includeIfNull: includeIfNull,
               );
           }
         }

--- a/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
@@ -11,6 +11,7 @@ import 'dart_import_dto_template.dart';
 String dartDartMappableDtoTemplate(
   UniversalComponentClass dataClass, {
   required bool markFileAsGenerated,
+  required bool includeIfNull,
 }) {
   final className = dataClass.name.toPascal;
   return '''
@@ -19,7 +20,7 @@ ${dartImportDtoTemplate(JsonSerializer.dartMappable)}
 ${dartImports(imports: dataClass.imports)}
 part '${dataClass.name.toSnake}.mapper.dart';
 
-${descriptionComment(dataClass.description)}@MappableClass()
+${descriptionComment(dataClass.description)}@MappableClass(${_includeIfNull(includeIfNull)})
 class $className with ${className}Mappable {
 
 ${indentation(2)}const $className(${getParameters(dataClass)});
@@ -40,6 +41,9 @@ String getParameters(UniversalComponentClass dataClass) {
     return '';
   }
 }
+
+String _includeIfNull(bool includeIfNull) =>
+    includeIfNull ? '' : 'ignoreNull: true';
 
 String getFields(UniversalComponentClass dataClass) {
   if (dataClass.parameters.isNotEmpty) {

--- a/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
@@ -10,6 +10,7 @@ import '../model/programming_language.dart';
 String dartFreezedDtoTemplate(
   UniversalComponentClass dataClass, {
   required bool markFileAsGenerated,
+  required bool includeIfNull,
 }) {
   final className = dataClass.name.toPascal;
   return '''
@@ -21,7 +22,7 @@ part '${dataClass.name.toSnake}.freezed.dart';
 part '${dataClass.name.toSnake}.g.dart';
 
 ${descriptionComment(dataClass.description)}@Freezed()
-class $className with _\$$className {
+class $className with _\$$className {${_includeIfNull(includeIfNull)}
   const factory $className(${dataClass.parameters.isNotEmpty ? '{' : ''}${_parametersToString(
     dataClass.parameters,
   )}${dataClass.parameters.isNotEmpty ? '\n  }' : ''}) = _$className;
@@ -29,6 +30,9 @@ class $className with _\$$className {
 }
 ''';
 }
+
+String _includeIfNull(bool includeIfNull) =>
+    includeIfNull ? '' : '\n@JsonSerializable(includeIfNull: false)';
 
 String _parametersToString(List<UniversalType> parameters) {
   final sortedByRequired =

--- a/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
@@ -10,6 +10,7 @@ import '../model/programming_language.dart';
 String dartJsonSerializableDtoTemplate(
   UniversalComponentClass dataClass, {
   required bool markFileAsGenerated,
+  required bool includeIfNull,
 }) {
   final className = dataClass.name.toPascal;
   return '''
@@ -19,7 +20,7 @@ ${generatedFileComment(
 ${dartImports(imports: dataClass.imports)}
 part '${dataClass.name.toSnake}.g.dart';
 
-${descriptionComment(dataClass.description)}@JsonSerializable()
+${descriptionComment(dataClass.description)}@JsonSerializable(${_includeIfNull(includeIfNull)})
 class $className {
   const $className(${dataClass.parameters.isNotEmpty ? '{' : ''}${_parametersInConstructor(
     dataClass.parameters,
@@ -31,6 +32,9 @@ class $className {
 }
 ''';
 }
+
+String _includeIfNull(bool includeIfNull) =>
+    includeIfNull ? '' : 'includeIfNull: false';
 
 String _parametersInClass(List<UniversalType> parameters) => parameters
     .mapIndexed(

--- a/swagger_parser/lib/src/parser/model/universal_component_class.dart
+++ b/swagger_parser/lib/src/parser/model/universal_component_class.dart
@@ -8,6 +8,7 @@ final class UniversalComponentClass extends UniversalDataClass {
     required super.name,
     required this.imports,
     required this.parameters,
+    this.includeIfNull = false,
     this.allOf,
     this.typeDef = false,
     super.description,
@@ -15,6 +16,8 @@ final class UniversalComponentClass extends UniversalDataClass {
 
   /// List of additional references to components
   final Set<String> imports;
+
+  final bool includeIfNull;
 
   /// List of class fields
   final List<UniversalType> parameters;

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -2759,4 +2759,69 @@ data class ClassName(
       expect(filledContent.content, expectedContent);
     });
   });
+
+  group('includeIfNull', () {
+    test('dart + json_serializable', () async {
+      const dataClass = UniversalComponentClass(
+        name: 'ClassName',
+        imports: {},
+        parameters: [],
+      );
+      const fillController = FillController(
+        config: GeneratorConfig(
+          name: '',
+          outputDirectory: '',
+          includeIfNull: false,
+        ),
+      );
+      final filledContent = fillController.fillDtoContent(dataClass);
+      const expectedContents = r'''
+import 'package:json_annotation/json_annotation.dart';
+
+part 'class_name.g.dart';
+
+@JsonSerializable(includeIfNull: false)
+class ClassName {
+  const ClassName();
+  
+  factory ClassName.fromJson(Map<String, Object?> json) => _$ClassNameFromJson(json);
+  
+  Map<String, Object?> toJson() => _$ClassNameToJson(this);
+}
+''';
+      expect(filledContent.content, expectedContents);
+    });
+  });
+
+  test('dart + freezed', () async {
+    const dataClass = UniversalComponentClass(
+      name: 'ClassName',
+      imports: {},
+      parameters: [],
+    );
+    const fillController = FillController(
+      config: GeneratorConfig(
+        name: '',
+        outputDirectory: '',
+        jsonSerializer: JsonSerializer.freezed,
+        includeIfNull: false,
+      ),
+    );
+    final filledContent = fillController.fillDtoContent(dataClass);
+    const expectedContents = r'''
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'class_name.freezed.dart';
+part 'class_name.g.dart';
+
+@Freezed()
+class ClassName with _$ClassName {
+@JsonSerializable(includeIfNull: false)
+  const factory ClassName() = _ClassName;
+  
+  factory ClassName.fromJson(Map<String, Object?> json) => _$ClassNameFromJson(json);
+}
+''';
+    expect(filledContent.content, expectedContents);
+  });
 }


### PR DESCRIPTION
**Issue:**  [includeIfNull for @JsonSerializable in the configuration #241](https://github.com/Carapacik/swagger_parser/issues/241)

**What has been changed:**
The include_if_null option has been added to the global configuration (enabled by default).
Added implementation for dart_mappable, json_serializable, and freezed