### PR TITLE
Added dio options parameter

### DIFF
--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -85,6 +85,11 @@ swagger_parser:
   # If the value is 'true', then the annotation will be added to all requests.
   extras_parameter_by_default: false
 
+  # Optional (dart only).
+  # Support @DioOptions annotation for interceptors.
+  # If the value is 'true', then the annotation will be added to all requests.
+  dio_options_parameter_by_default: false
+
   # Optional (dart only). Set 'true' to generate root client
   # with interface and all clients instances.
   root_client: true

--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -28,6 +28,7 @@ class SWPConfig {
     this.replacementRules = const [],
     this.defaultContentType = 'application/json',
     this.extrasParameterByDefault = false,
+    this.dioOptionsParameterByDefault = false,
     this.pathMethodName = false,
     this.mergeClients = false,
     this.enumsParentPrefix = true,
@@ -54,6 +55,7 @@ class SWPConfig {
     required this.replacementRules,
     required this.defaultContentType,
     required this.extrasParameterByDefault,
+    required this.dioOptionsParameterByDefault,
     required this.pathMethodName,
     required this.mergeClients,
     required this.enumsParentPrefix,
@@ -121,6 +123,14 @@ class SWPConfig {
     if (extrasParameterByDefault is! bool?) {
       throw const ConfigException(
         "Config parameter 'extras_parameter_by_default' must be bool.",
+      );
+    }
+
+    final dioOptionsParameterByDefault =
+        yamlMap['dio_options_parameter_by_default'];
+    if (dioOptionsParameterByDefault is! bool?) {
+      throw const ConfigException(
+        "Config parameter 'dio_options_parameter_by_default' must be bool.",
       );
     }
 
@@ -285,6 +295,8 @@ class SWPConfig {
       defaultContentType: defaultContentType ?? dc.defaultContentType,
       extrasParameterByDefault:
           extrasParameterByDefault ?? dc.extrasParameterByDefault,
+      dioOptionsParameterByDefault:
+          dioOptionsParameterByDefault ?? dc.dioOptionsParameterByDefault,
       mergeClients: mergeClients ?? dc.mergeClients,
       enumsParentPrefix: enumsParentPrefix ?? dc.enumsParentPrefix,
       skippedParameters: skippedParameters ?? dc.skippedParameters,
@@ -380,6 +392,16 @@ class SWPConfig {
   /// ```
   final bool extrasParameterByDefault;
 
+  /// DART ONLY
+  /// Add dio options parameter to all requests.
+  ///
+  /// If  value is 'true', then the annotation will be added to all requests.
+  /// ```dart
+  /// @POST('/path/')
+  /// Future<String> myMethod({@DioOptions() RequestOptions? options});
+  /// ```
+  final bool dioOptionsParameterByDefault;
+
   /// If `true`, use the endpoint path for the method name.
   /// if `false`, use `operationId`.
   final bool pathMethodName;
@@ -402,6 +424,7 @@ class SWPConfig {
       jsonSerializer: jsonSerializer,
       defaultContentType: defaultContentType,
       extrasParameterByDefault: extrasParameterByDefault,
+      dioOptionsParameterByDefault: dioOptionsParameterByDefault,
       rootClient: rootClient,
       rootClientName: rootClientName,
       clientPostfix: clientPostfix,

--- a/swagger_parser/lib/src/generator/config/generator_config.dart
+++ b/swagger_parser/lib/src/generator/config/generator_config.dart
@@ -13,6 +13,7 @@ class GeneratorConfig {
     this.defaultContentType = 'application/json',
     this.rootClient = true,
     this.extrasParameterByDefault = false,
+    this.dioOptionsParameterByDefault = false,
     this.rootClientName = 'RestClient',
     this.clientPostfix,
     this.exportFile = true,
@@ -90,6 +91,16 @@ class GeneratorConfig {
   /// Future<String> myMethod({@Extras() Map<String, dynamic>? extras});
   /// ```
   final bool extrasParameterByDefault;
+
+  /// DART ONLY
+  /// Add dio options parameter to all requests.
+  ///
+  /// If  value is 'true', then the annotation will be added to all requests.
+  /// ```dart
+  /// @POST('/path/')
+  /// Future<String> myMethod({@DioOptions() RequestOptions? options});
+  /// ```
+  final bool dioOptionsParameterByDefault;
 
   /// Optional. Set regex replacement rules for the names of the generated classes/enums.
   /// All rules are applied in order.

--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -49,6 +49,7 @@ final class FillController {
         markFilesAsGenerated: config.markFilesAsGenerated,
         defaultContentType: config.defaultContentType,
         extrasParameterByDefault: config.extrasParameterByDefault,
+        dioOptionsParameterByDefault: config.dioOptionsParameterByDefault,
         originalHttpResponse: config.originalHttpResponse,
       ),
     );

--- a/swagger_parser/lib/src/generator/model/programming_language.dart
+++ b/swagger_parser/lib/src/generator/model/programming_language.dart
@@ -110,6 +110,7 @@ enum ProgrammingLanguage {
     required bool markFilesAsGenerated,
     required String defaultContentType,
     bool extrasParameterByDefault = false,
+    bool dioOptionsParameterByDefault = false,
     bool originalHttpResponse = false,
   }) =>
       switch (this) {
@@ -119,6 +120,7 @@ enum ProgrammingLanguage {
             markFileAsGenerated: markFilesAsGenerated,
             defaultContentType: defaultContentType,
             extrasParameterByDefault: extrasParameterByDefault,
+            dioOptionsParameterByDefault: dioOptionsParameterByDefault,
             originalHttpResponse: originalHttpResponse,
           ),
         kotlin => kotlinRetrofitClientTemplate(

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -13,6 +13,7 @@ String dartRetrofitClientTemplate({
   required bool markFileAsGenerated,
   required String defaultContentType,
   bool extrasParameterByDefault = false,
+  bool dioOptionsParameterByDefault = false,
   bool originalHttpResponse = false,
 }) {
   final sb = StringBuffer(
@@ -36,6 +37,7 @@ abstract class $name {
         defaultContentType,
         originalHttpResponse: originalHttpResponse,
         extrasParameterByDefault: extrasParameterByDefault,
+        dioOptionsParameterByDefault: dioOptionsParameterByDefault,
       ),
     );
   }
@@ -48,6 +50,7 @@ String _toClientRequest(
   String defaultContentType, {
   required bool originalHttpResponse,
   required bool extrasParameterByDefault,
+  required bool dioOptionsParameterByDefault,
 }) {
   final responseType = request.returnType == null
       ? 'void'
@@ -58,7 +61,9 @@ String _toClientRequest(
   ${descriptionComment(request.description, tabForFirstLine: false, tab: '  ', end: '  ')}${request.isDeprecated ? "@Deprecated('This method is marked as deprecated')\n  " : ''}${_contentTypeHeader(request, defaultContentType)}@${request.requestType.name.toUpperCase()}('${request.route}')
   Future<${originalHttpResponse ? 'HttpResponse<$responseType>' : responseType}> ${request.name}(''',
   );
-  if (request.parameters.isNotEmpty || extrasParameterByDefault) {
+  if (request.parameters.isNotEmpty ||
+      extrasParameterByDefault ||
+      dioOptionsParameterByDefault) {
     sb.write('{\n');
   }
   final sortedByRequired = List<UniversalRequestType>.from(
@@ -70,7 +75,12 @@ String _toClientRequest(
   if (extrasParameterByDefault) {
     sb.write(_addExtraParameter());
   }
-  if (request.parameters.isNotEmpty || extrasParameterByDefault) {
+  if (dioOptionsParameterByDefault) {
+    sb.write(_addDioOptionsParameter());
+  }
+  if (request.parameters.isNotEmpty ||
+      extrasParameterByDefault ||
+      dioOptionsParameterByDefault) {
     sb.write('  });\n');
   } else {
     sb.write(');\n');
@@ -96,6 +106,9 @@ String _fileImport(UniversalRestClient restClient) => restClient.requests.any(
         : '';
 
 String _addExtraParameter() => '    @Extras() Map<String, dynamic>? extras,\n';
+
+String _addDioOptionsParameter() =>
+    '    @DioOptions() RequestOptions? options,\n';
 
 String _toParameter(UniversalRequestType parameter) {
   var parameterType = parameter.type.toSuitableType(ProgrammingLanguage.dart);


### PR DESCRIPTION
I suggest adding the "RequestOptions" transfer using the "@DioOptions" annotation, as this is a very important part of Dio and will allow transferring CancelToken, onReceiveProgress, etc. to requests. I need to be able to cancel requests, but now, in order to transfer, for example, CancelToken, I need to write it manually, and when regenerating it will be erased and I will have to write everything again. If the PR is approved, I will write tests