### PR TITLE
Add Open API version number to root client

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 1.18.3
+- Add version getter to root client
+
+## 1.18.3
 - Remove support of BigInt in Dart for `int64` types
 
 ## 1.18.2

--- a/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
@@ -45,6 +45,8 @@ ${descriptionComment(comment)}class $className {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '${openApiInfo.apiVersion ?? ''}';
+
 ${_privateFields(clientsNames, postfix)}
 
 ${_getters(clientsNames, postfix)}

--- a/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
@@ -45,7 +45,7 @@ ${descriptionComment(comment)}class $className {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '${openApiInfo.apiVersion ?? ''}';
+  static String get version => '${openApiInfo.apiVersion ?? ''}';
 
 ${_privateFields(clientsNames, postfix)}
 

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.18.3
+version: 1.18.4
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 topics:
   - swagger

--- a/swagger_parser/test/e2e/tests/basic/additional_properties_class.2.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/additional_properties_class.2.0/expected_files/rest_client.dart
@@ -19,6 +19,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '1.0';
+
   TestClient? _test;
 
   TestClient get test => _test ??= TestClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/basic/additional_properties_class.2.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/additional_properties_class.2.0/expected_files/rest_client.dart
@@ -19,7 +19,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '1.0';
+  static String get version => '1.0';
 
   TestClient? _test;
 

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   AuthClient? _auth;
   UserClient? _user;

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '';
+
   AuthClient? _auth;
   UserClient? _user;
 

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   AuthClient? _auth;
   UserClient? _user;

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '';
+
   AuthClient? _auth;
   UserClient? _user;
 

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '1.0.0';
+
   ClientClient? _client;
 
   ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '1.0.0';
+  static String get version => '1.0.0';
 
   ClientClient? _client;
 

--- a/swagger_parser/test/e2e/tests/enum_member_names/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/enum_member_names/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '0.0.0 (v1)';
+
   ApiClient? _api;
 
   ApiClient get api => _api ??= ApiClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/enum_member_names/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/enum_member_names/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '0.0.0 (v1)';
+  static String get version => '0.0.0 (v1)';
 
   ApiClient? _api;
 

--- a/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/rest_client.dart
@@ -16,7 +16,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   ClientClient? _client;
 

--- a/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/rest_client.dart
@@ -16,6 +16,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '';
+
   ClientClient? _client;
 
   ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '1.0.0';
+
   ClientClient? _client;
 
   ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '1.0.0';
+  static String get version => '1.0.0';
 
   ClientClient? _client;
 

--- a/swagger_parser/test/e2e/tests/nullable_types/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types/expected_files/rest_client.dart
@@ -17,6 +17,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '0.0.0 (v1)';
+
   ApiClient? _api;
 
   ApiClient get api => _api ??= ApiClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/e2e/tests/nullable_types/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types/expected_files/rest_client.dart
@@ -17,7 +17,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '0.0.0 (v1)';
+  static String get version => '0.0.0 (v1)';
 
   ApiClient? _api;
 

--- a/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/rest_client.dart
@@ -16,7 +16,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   ClientClient? _client;
 

--- a/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/rest_client.dart
@@ -16,6 +16,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '';
+
   ClientClient? _client;
 
   ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);

--- a/swagger_parser/test/generator/root_client_test.dart
+++ b/swagger_parser/test/generator/root_client_test.dart
@@ -41,7 +41,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '1.0.0';
+  static String get version => '1.0.0';
 
   OneClient? _one;
 
@@ -76,7 +76,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   OneClient? _one;
 
@@ -119,7 +119,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   OneClient? _one;
   TwoClient? _two;
@@ -170,7 +170,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   OneClient? _one;
 
@@ -217,7 +217,7 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
-  String get version => '';
+  static String get version => '';
 
   OneClient? _one;
   TwoClient? _two;

--- a/swagger_parser/test/generator/root_client_test.dart
+++ b/swagger_parser/test/generator/root_client_test.dart
@@ -15,6 +15,43 @@ void main() {
     });
   });
 
+  group('Version getter', () {
+    test('dart', () async {
+      final clients = [
+        const UniversalRestClient(name: 'One', imports: {}, requests: []),
+      ];
+      const fillController = FillController(
+        config: GeneratorConfig(name: '', outputDirectory: ''),
+        info: OpenApiInfo(apiVersion: '1.0.0', schemaVersion: OAS.v3_1),
+      );
+      final filledContent = fillController.fillRootClient(clients);
+      const expectedContents = '''
+import 'package:dio/dio.dart';
+
+import 'one/one_client.dart';
+
+///  `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  String get version => '1.0.0';
+
+  OneClient? _one;
+
+  OneClient get one => _one ??= OneClient(_dio, baseUrl: _baseUrl);
+}
+''';
+      expect(filledContent.content, expectedContents);
+    });
+  });
+
   group('root client with one client', () {
     test('dart', () async {
       final clients = [
@@ -38,6 +75,8 @@ class RestClient {
 
   final Dio _dio;
   final String? _baseUrl;
+
+  String get version => '';
 
   OneClient? _one;
 
@@ -79,6 +118,8 @@ class RestClient {
 
   final Dio _dio;
   final String? _baseUrl;
+
+  String get version => '';
 
   OneClient? _one;
   TwoClient? _two;
@@ -129,6 +170,8 @@ class RestClient {
   final Dio _dio;
   final String? _baseUrl;
 
+  String get version => '';
+
   OneClient? _one;
 
   OneClient get one => _one ??= OneClient(_dio, baseUrl: _baseUrl);
@@ -173,6 +216,8 @@ class RestClient {
 
   final Dio _dio;
   final String? _baseUrl;
+
+  String get version => '';
 
   OneClient? _one;
   TwoClient? _two;


### PR DESCRIPTION
## Add Open API version number to root client
Sometimes, developers specify the version used in the application. It’s also useful to add a request header like `X-API-Version: 1.0.0`.

### API Spec
```json
{
  "openapi": "3.0.0",
  "info": {
    "version": "1.0.0"
  }
}
```

### Usage
```dart
final client = RestClient(dio);

// 1.0.0
print(RestClient.version);

client.someApi.getRequest(
  extras: { 
    'custom-header': { 
      'X-API-Version': '${RestClient.version}' 
    }
  }
);
```