### PR TITLE
fix: return empty Map when schema properties is null

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -361,8 +361,12 @@ class OpenApiParser {
             requiredParameters =
                 required?.map((e) => e.toString()).toList() ?? [];
           } else {
-            properties =
-                schemaContent[_propertiesConst] as Map<String, dynamic>;
+            if (schemaContent[_propertiesConst] is Map<String, dynamic>) {
+              properties =
+                  schemaContent[_propertiesConst] as Map<String, dynamic>;
+            } else {
+              properties = {};
+            }
             requiredParameters =
                 (schemaContent[_requiredConst] as List<dynamic>?)
                         ?.map((e) => e.toString())


### PR DESCRIPTION
Return empty Map when schema properties is not Map<String, dynamic> type to prevent null safety runtime errors. (#280)