### PR TITLE
Implement support for discriminated unions

### DIFF
--- a/swagger_parser/lib/src/parser/model/universal_component_class.dart
+++ b/swagger_parser/lib/src/parser/model/universal_component_class.dart
@@ -10,6 +10,7 @@ final class UniversalComponentClass extends UniversalDataClass {
     required this.parameters,
     this.allOf,
     this.typeDef = false,
+    this.discriminator,
     super.description,
   });
 
@@ -21,6 +22,18 @@ final class UniversalComponentClass extends UniversalDataClass {
 
   /// Temp field for containing info about `allOf` for future processing
   final ({List<String> refs, List<UniversalType> properties})? allOf;
+
+  /// When using a discriminated oneOf, this contains the information about the property name, the mapping of the ref to the property name, and the properties of each of the oneOf variants
+  final ({
+    // The name of the property that is used to discriminate the oneOf variants
+    String propertyName,
+
+    // The mapping of the property value to the ref
+    Map<String, String> discriminatorValueToRefMapping,
+
+    // The list of properties stored for each ref
+    Map<String, List<UniversalType>> refProperties,
+  })? discriminator;
 
   /// Whether or not this schema is a basic type
   /// "Date": {

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -54,12 +54,14 @@ class OpenApiParser {
   static const _definitionsConst = 'definitions';
   static const _descriptionConst = 'description';
   static const _deprecatedConst = 'deprecated';
+  static const _discriminatorConst = 'discriminator';
   static const _enumConst = 'enum';
   static const _formatConst = 'format';
   static const _formUrlEncodedConst = 'application/x-www-form-urlencoded';
   static const _inConst = 'in';
   static const _infoConst = 'info';
   static const _itemsConst = 'items';
+  static const _mappingConst = 'mapping';
   static const _multipartFormDataConst = 'multipart/form-data';
   static const _nameConst = 'name';
   static const _nullableConst = 'nullable';
@@ -70,6 +72,7 @@ class OpenApiParser {
   static const _parametersConst = 'parameters';
   static const _pathsConst = 'paths';
   static const _propertiesConst = 'properties';
+  static const _propertyNameConst = 'propertyName';
   static const _refConst = r'$ref';
   static const _requestBodyConst = 'requestBody';
   static const _requestBodiesConst = 'requestBodies';
@@ -895,6 +898,26 @@ class OpenApiParser {
       }
       allOfClass.parameters.addAll(allOfClass.allOf!.properties);
     }
+
+    // check for discriminated oneOf
+    final discriminatedOneOfClasses = dataClasses.where(
+        (dc) => dc is UniversalComponentClass && dc.discriminator != null);
+    for (final discriminatedOneOfClass in discriminatedOneOfClasses) {
+      if (discriminatedOneOfClass is! UniversalComponentClass) {
+        continue;
+      }
+      final discriminator = discriminatedOneOfClass.discriminator!;
+      // for each ref, we lookup the matching dataclass and add its properties to the discriminator mapping, its imports are added to the discriminatedOneOfClass's imports
+      for (final ref in discriminator.discriminatorValueToRefMapping.values) {
+        final refedClass = dataClasses.firstWhere((dc) => dc.name == ref);
+        if (refedClass is! UniversalComponentClass) {
+          continue;
+        }
+        discriminator.refProperties[ref] = refedClass.parameters;
+        discriminatedOneOfClass.imports.addAll(refedClass.imports);
+      }
+    }
+
     return dataClasses;
   }
 
@@ -931,7 +954,7 @@ class OpenApiParser {
       final (:type, :import) = _findType(
         arrayItems,
         name: name,
-        additionalName: name,
+        additionalName: additionalName,
         root: false,
         isRequired: isRequired,
       );
@@ -1122,9 +1145,69 @@ class OpenApiParser {
         map.containsKey(_anyOfConst) ||
         map.containsKey(_oneOfConst) ||
         map[_typeConst] is List) {
+      // Handle discriminated oneOf
+      if (map.containsKey(_oneOfConst) &&
+          map.containsKey(_discriminatorConst) &&
+          (map[_discriminatorConst] as Map<String, dynamic>)
+              .containsKey(_propertyNameConst) &&
+          (map[_discriminatorConst] as Map<String, dynamic>)
+              .containsKey(_mappingConst)) {
+        final discriminator = map[_discriminatorConst] as Map<String, dynamic>;
+        final propertyName = discriminator[_propertyNameConst] as String;
+        final refMapping = discriminator[_mappingConst] as Map<String, dynamic>;
+
+        // Create a base union class for the discriminated types
+        final baseClassName =
+            '${additionalName ?? ''} ${name ?? ''} Union'.toPascal;
+        final (newName, description) = protectName(
+          baseClassName,
+          uniqueIfNull: true,
+          description: map[_descriptionConst]?.toString(),
+        );
+
+        // Cleanup the refMapping to contain only the class name
+        final cleanedRefMapping = <String, String>{};
+        for (final key in refMapping.keys) {
+          final refMap = <String, dynamic>{_refConst: refMapping[key]};
+          cleanedRefMapping[key] = _formatRef(refMap);
+        }
+
+        // Create a sealed class to represent the discriminated union
+        _objectClasses.add(
+          UniversalComponentClass(
+            name: newName!.toPascal,
+            imports: SplayTreeSet<String>(),
+            parameters: [
+              UniversalType(
+                type: 'String',
+                name: propertyName,
+                isRequired: true,
+              ),
+            ],
+            discriminator: (
+              propertyName: propertyName,
+              discriminatorValueToRefMapping: cleanedRefMapping,
+              // This property is populated by the parser after all the data classes are created
+              refProperties: <String, List<UniversalType>>{},
+            ),
+          ),
+        );
+
+        return (
+          type: UniversalType(
+            type: newName.toPascal,
+            name: name?.toCamel,
+            description: description,
+            isRequired: isRequired,
+            nullable: map[_nullableConst].toString().toBool() ??
+                (root && !isRequired),
+          ),
+          import: newName.toPascal,
+        );
+      }
+
       String? ofImport;
       UniversalType? ofType;
-
       final ofList = map[_allOfConst] ??
           map[_anyOfConst] ??
           map[_oneOfConst] ??

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -185,6 +185,19 @@ void main() {
       );
     });
 
+    test('discriminated_one_of.3.0', () async {
+      await e2eTest(
+        'basic/discriminated_one_of.3.0',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'discriminated_one_of.3.0.json',
+      );
+    });
+
     test('empty_class.2.0', () async {
       await e2eTest(
         'basic/empty_class.2.0',

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/discriminated_one_of.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/discriminated_one_of.3.0.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Family API",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Family": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Cat"
+                },
+                {
+                  "$ref": "#/components/schemas/Dog"
+                },
+                {
+                  "$ref": "#/components/schemas/Human"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                  "Cat": "#/components/schemas/Cat",
+                  "Dog": "#/components/schemas/Dog",
+                  "Human": "#/components/schemas/Human"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Cat": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Cat"]
+          },
+          "mewCount": {
+            "type": "integer",
+            "description": "Number of times the cat meows."
+          }
+        },
+        "required": ["type", "mewCount"]
+      },
+      "Dog": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Dog"]
+          },
+          "barkSound": {
+            "type": "string",
+            "description": "The sound of the dog's bark."
+          }
+        },
+        "required": ["type", "barkSound"]
+      },
+      "Human": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Human"]
+          },
+          "job": {
+            "type": "string",
+            "description": "The job of the human."
+          }
+        },
+        "required": ["type", "job"]
+      }
+    }
+  }
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/export.dart
@@ -1,0 +1,13 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Data classes
+export 'models/family.dart';
+export 'models/cat.dart';
+export 'models/dog.dart';
+export 'models/human.dart';
+export 'models/family_members_union.dart';
+export 'models/cat_type.dart';
+export 'models/dog_type.dart';
+export 'models/human_type.dart';

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/cat.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/cat.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'cat_type.dart';
+
+part 'cat.freezed.dart';
+part 'cat.g.dart';
+
+@Freezed()
+class Cat with _$Cat {
+  const factory Cat({
+    required CatType type,
+
+    /// Number of times the cat meows.
+    required int mewCount,
+  }) = _Cat;
+
+  factory Cat.fromJson(Map<String, Object?> json) => _$CatFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/cat_type.dart
@@ -5,20 +5,16 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
-enum StatusStatus {
-  @JsonValue('available')
-  available('available'),
-  @JsonValue('pending')
-  pending('pending'),
-  @JsonValue('sold')
-  sold('sold'),
+enum CatType {
+  @JsonValue('Cat')
+  cat('Cat'),
 
   /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
   $unknown(null);
 
-  const StatusStatus(this.json);
+  const CatType(this.json);
 
-  factory StatusStatus.fromJson(String json) => values.firstWhere(
+  factory CatType.fromJson(String json) => values.firstWhere(
         (e) => e.json == json,
         orElse: () => $unknown,
       );

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/dog.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/dog.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'dog_type.dart';
+
+part 'dog.freezed.dart';
+part 'dog.g.dart';
+
+@Freezed()
+class Dog with _$Dog {
+  const factory Dog({
+    required DogType type,
+
+    /// The sound of the dog's bark.
+    required String barkSound,
+  }) = _Dog;
+
+  factory Dog.fromJson(Map<String, Object?> json) => _$DogFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/dog_type.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum DogType {
+  @JsonValue('Dog')
+  dog('Dog'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const DogType(this.json);
+
+  factory DogType.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'family_members_union.dart';
+
+part 'family.freezed.dart';
+part 'family.g.dart';
+
+@Freezed()
+class Family with _$Family {
+  const factory Family({
+    required List<FamilyMembersUnion> members,
+  }) = _Family;
+
+  factory Family.fromJson(Map<String, Object?> json) => _$FamilyFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family_members_union.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family_members_union.dart
@@ -1,0 +1,42 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'cat_type.dart';
+import 'dog_type.dart';
+import 'human_type.dart';
+
+part 'family_members_union.freezed.dart';
+part 'family_members_union.g.dart';
+
+@Freezed(unionKey: 'type')
+sealed class FamilyMembersUnion with _$FamilyMembersUnion {
+  @FreezedUnionValue('Cat')
+  const factory FamilyMembersUnion.cat({
+    required CatType type,
+
+    /// Number of times the cat meows.
+    required int mewCount,
+  }) = Cat;
+
+  @FreezedUnionValue('Dog')
+  const factory FamilyMembersUnion.dog({
+    required DogType type,
+
+    /// The sound of the dog's bark.
+    required String barkSound,
+  }) = Dog;
+
+  @FreezedUnionValue('Human')
+  const factory FamilyMembersUnion.human({
+    required HumanType type,
+
+    /// The job of the human.
+    required String job,
+  }) = Human;
+
+  factory FamilyMembersUnion.fromJson(Map<String, Object?> json) =>
+      _$FamilyMembersUnionFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/human.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/human.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'human_type.dart';
+
+part 'human.freezed.dart';
+part 'human.g.dart';
+
+@Freezed()
+class Human with _$Human {
+  const factory Human({
+    required HumanType type,
+
+    /// The job of the human.
+    required String job,
+  }) = _Human;
+
+  factory Human.fromJson(Map<String, Object?> json) => _$HumanFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/human_type.dart
@@ -5,20 +5,16 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 @JsonEnum()
-enum StatusStatus {
-  @JsonValue('available')
-  available('available'),
-  @JsonValue('pending')
-  pending('pending'),
-  @JsonValue('sold')
-  sold('sold'),
+enum HumanType {
+  @JsonValue('Human')
+  human('Human'),
 
   /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
   $unknown(null);
 
-  const StatusStatus(this.json);
+  const HumanType(this.json);
 
-  factory StatusStatus.fromJson(String json) => values.firstWhere(
+  factory HumanType.fromJson(String json) => values.firstWhere(
         (e) => e.json == json,
         orElse: () => $unknown,
       );

--- a/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/export.dart
@@ -4,4 +4,4 @@
 
 // Data classes
 export 'models/class_name.dart';
-export 'models/status_status.dart';
+export 'models/class_name_status.dart';

--- a/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name.dart
+++ b/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name.dart
@@ -4,7 +4,7 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'status_status.dart';
+import 'class_name_status.dart';
 
 part 'class_name.freezed.dart';
 part 'class_name.g.dart';
@@ -13,7 +13,7 @@ part 'class_name.g.dart';
 class ClassName with _$ClassName {
   const factory ClassName({
     /// Status values that need to be considered for filter
-    required List<StatusStatus> status,
+    required List<ClassNameStatus> status,
   }) = _ClassName;
 
   factory ClassName.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name_status.dart
@@ -1,0 +1,27 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum ClassNameStatus {
+  @JsonValue('available')
+  available('available'),
+  @JsonValue('pending')
+  pending('pending'),
+  @JsonValue('sold')
+  sold('sold'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const ClassNameStatus(this.json);
+
+  factory ClassNameStatus.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+}

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/clients/pet_client.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/clients/pet_client.dart
@@ -7,7 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
 import '../models/pet.dart';
-import '../models/status_status.dart';
+import '../models/status.dart';
 
 part 'pet_client.g.dart';
 
@@ -38,7 +38,7 @@ abstract class PetClient {
   /// [status] - Status values that need to be considered for filter.
   @GET('/pet/findByStatus')
   Future<List<Pet>> findPetsByStatus({
-    @Query('status') required List<StatusStatus> status,
+    @Query('status') required List<Status> status,
   });
 
   /// Finds Pets by tags.

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/export.dart
@@ -7,7 +7,7 @@ export 'clients/pet_client.dart';
 // Data classes
 export 'models/category.dart';
 export 'models/pet.dart';
-export 'models/status_status.dart';
+export 'models/status.dart';
 export 'models/pet_status.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/status.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/status.dart
@@ -1,0 +1,27 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum Status {
+  @JsonValue('available')
+  available('available'),
+  @JsonValue('pending')
+  pending('pending'),
+  @JsonValue('sold')
+  sold('sold'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const Status(this.json);
+
+  factory Status.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+}


### PR DESCRIPTION
This PR introduces support for OpenAPI discriminator patterns in oneOf schemas. The implementation enables proper code generation for polymorphic types.

Key Changes:
- Added discriminator handling within `UniversalComponentClass` for `oneOf` variant support
- Enhanced `OpenApiParser` to correctly process discriminator mappings from OpenAPI specs
- Updated Freezed DTO template to generate sealed classes with union factories
- Anonymous class naming now uses the parent class name as context (e.g., `ClassNameStatus` instead of `StatusStatus`)
- Added comprehensive test cases with sample schemas and expected outputs

This PR does not support any other generator and I still have to test a few things with the Freezed one.
I will remove its `DRAFT` status once I think it is ready. 

closes #286 
closes #265 