### PR TITLE
feat: add config option to know if schema is using x-nullable extension

### DIFF
--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -34,6 +34,7 @@ class SWPConfig {
     this.enumsParentPrefix = true,
     this.skippedParameters = const <String>[],
     this.generateValidator = false,
+    this.useXNullable = false,
   });
 
   /// Internal constructor of [SWPConfig]
@@ -62,6 +63,7 @@ class SWPConfig {
     required this.enumsParentPrefix,
     required this.skippedParameters,
     required this.generateValidator,
+    required this.useXNullable,
   });
 
   /// Creates a [SWPConfig] from [YamlMap].
@@ -204,6 +206,9 @@ class SWPConfig {
     final generateValidator =
         yamlMap['generate_validator'] as bool? ?? rootConfig?.generateValidator;
 
+    final useXNullable =
+        yamlMap['use_x_nullable'] as bool? ?? rootConfig?.useXNullable;
+
     // Default config
     final dc = SWPConfig(name: name, outputDirectory: outputDirectory);
 
@@ -234,6 +239,7 @@ class SWPConfig {
       originalHttpResponse: originalHttpResponse ?? dc.originalHttpResponse,
       replacementRules: replacementRules ?? dc.replacementRules,
       generateValidator: generateValidator ?? dc.generateValidator,
+      useXNullable: useXNullable ?? dc.useXNullable,
     );
   }
 
@@ -340,6 +346,9 @@ class SWPConfig {
   /// Set `true` to generate validator for freezed.
   final bool generateValidator;
 
+  /// Set `true` if Schema uses x-nullable to indicate nullable fields
+  final bool useXNullable;
+
   /// Convert [SWPConfig] to [GeneratorConfig]
   GeneratorConfig toGeneratorConfig() {
     return GeneratorConfig(
@@ -379,6 +388,7 @@ class SWPConfig {
       enumsParentPrefix: enumsParentPrefix,
       skippedParameters: skippedParameters,
       replacementRules: replacementRules,
+      useXNullable: useXNullable,
     );
   }
 }

--- a/swagger_parser/lib/src/parser/config/parser_config.dart
+++ b/swagger_parser/lib/src/parser/config/parser_config.dart
@@ -13,6 +13,7 @@ class ParserConfig {
     this.enumsParentPrefix = true,
     this.skippedParameters = const <String>[],
     this.replacementRules = const [],
+    this.useXNullable = false,
   });
 
   /// Specification file content as [String]
@@ -49,4 +50,8 @@ class ParserConfig {
   /// Optional. Set regex replacement rules for the names of the generated classes/enums.
   /// All rules are applied in order.
   final List<ReplacementRule> replacementRules;
+
+  /// Does the Schema use x-nullable to indicate nullable fields
+  /// Only used for OpenApi v2
+  final bool useXNullable;
 }

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -709,7 +709,9 @@ class OpenApiParser {
           propertyValue,
           name: propertyName,
           additionalName: additionalName,
-          isRequired: isRequired || !isNullable,
+          isRequired: (_apiInfo.schemaVersion == OAS.v2 && !config.useXNullable)
+              ? isRequired
+              : isRequired || !isNullable,
         );
 
         var validation = propertyValue;

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -100,6 +100,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'swagger.yaml',
       );
@@ -115,6 +116,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'additional_properties_class.2.0.json',
       );
@@ -141,6 +143,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'basic_requests.2.0.json',
       );
@@ -167,6 +170,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'basic_types_class.2.0.json',
       );
@@ -206,6 +210,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'empty_class.2.0.json',
       );
@@ -258,6 +263,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'reference_types_class.2.0.json',
       );
@@ -283,6 +289,7 @@ void main() {
           outputDirectory: outputDirectory,
           schemaPath: schemaPath,
           putClientsInFolder: true,
+          useXNullable: true,
           replacementRules: [
             ReplacementRule(pattern: RegExp('List'), replacement: 'Lizt'),
             ReplacementRule(pattern: RegExp(r'$'), replacement: 'DTO'),
@@ -317,6 +324,7 @@ void main() {
           schemaPath: schemaPath,
           jsonSerializer: JsonSerializer.freezed,
           putClientsInFolder: true,
+          useXNullable: true,
         ),
         schemaFileName: 'wrapping_collections.2.0.json',
       );


### PR DESCRIPTION
This PR adds a config parameter to check if the schema is using x-nullable extension or not, if the project is not using then x-nullable is not used in the parser. Without this change, all properties are considered required for Schema that do not use x-nullable.

**This is a breaking change**