### PR TITLE
Fix discriminator class naming conflicts

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
@@ -168,7 +168,7 @@ String _factories(UniversalComponentClass dataClass, String className) {
         .discriminator!.discriminatorValueToRefMapping[discriminatorValue]!;
     final factoryParameters =
         dataClass.discriminator!.refProperties[discriminatorRef]!;
-    final unionItemClassName = discriminatorRef.toPascal;
+    final unionItemClassName = className + discriminatorValue.toPascal;
 
     factories.add('''
   @FreezedUnionValue('$discriminatorValue')

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family_members_union.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/expected_files/models/family_members_union.dart
@@ -19,7 +19,7 @@ sealed class FamilyMembersUnion with _$FamilyMembersUnion {
 
     /// Number of times the cat meows.
     required int mewCount,
-  }) = Cat;
+  }) = FamilyMembersUnionCat;
 
   @FreezedUnionValue('Dog')
   const factory FamilyMembersUnion.dog({
@@ -27,7 +27,7 @@ sealed class FamilyMembersUnion with _$FamilyMembersUnion {
 
     /// The sound of the dog's bark.
     required String barkSound,
-  }) = Dog;
+  }) = FamilyMembersUnionDog;
 
   @FreezedUnionValue('Human')
   const factory FamilyMembersUnion.human({
@@ -35,7 +35,7 @@ sealed class FamilyMembersUnion with _$FamilyMembersUnion {
 
     /// The job of the human.
     required String job,
-  }) = Human;
+  }) = FamilyMembersUnionHuman;
 
   factory FamilyMembersUnion.fromJson(Map<String, Object?> json) =>
       _$FamilyMembersUnionFromJson(json);


### PR DESCRIPTION
Fixes #300

## Changes

Changed the union case class name generation to include the parent class name as prefix to avoid naming conflicts with standalone classes.

```dart
// Before
const factory ResponseItemsUnion.a(...) = ItemA;

// After
const factory ResponseItemsUnion.a(...) = ResponseItemsUnionA;
```

## Testing
- [x] E2E tests updated and passing
- [x] Build successful without export conflicts