### PR TITLE
dart mappable enums: toJson and default values

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
@@ -26,7 +26,7 @@ ${descriptionComment(dataClass.description)}@MappableClass(${() {
     if (dataClass.discriminator != null) {
       return [
         "discriminatorKey: '${dataClass.discriminator!.propertyName}'",
-        "includeSubClasses: [${dataClass.discriminator!.discriminatorValueToRefMapping.values.join(', ')}]"
+        "includeSubClasses: [${dataClass.discriminator!.discriminatorValueToRefMapping.values.join(', ')}]",
       ].join(", ");
     }
     if (dataClass.discriminatorValue != null) {

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -53,17 +53,32 @@ String _dartEnumDartMappableTemplate(
   final className = enumClass.name.toPascal;
   final jsonParam = unknownEnumValue || enumsToJson;
 
-  final values =
-      '${enumClass.items.mapIndexed((i, e) => _enumValueDartMappable(i, enumClass.type, e, jsonParam: jsonParam)).join(',\n')}${unknownEnumValue ? ',' : ';'}';
+  final values = [
+    ...enumClass.items,
+    if (unknownEnumValue)
+      const UniversalEnumItem(name: 'unknown', jsonKey: 'unknown'),
+  ]
+      .mapIndexed(
+        (i, e) =>
+            _enumValueDartMappable(i, enumClass.type, e, jsonParam: jsonParam),
+      )
+      .join(',\n');
+
+  final annotationParameters = [
+    if (unknownEnumValue) "defaultValue: 'unknown'",
+  ].join(', ');
+
+  final toJson = enumsToJson ? 'dynamic toJson() => toValue();' : '';
 
   return '''
 ${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${dartImportDtoTemplate(JsonSerializer.dartMappable)}
 
 part '${enumClass.name.toSnake}.mapper.dart';
 
-${descriptionComment(enumClass.description)}@MappableEnum()
+${descriptionComment(enumClass.description)}@MappableEnum($annotationParameters)
 enum $className {
-$values
+$values;
+$toJson
 }
 ''';
 }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/android_device_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/android_device_type.dart
@@ -6,8 +6,11 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'android_device_type.mapper.dart';
 
-@MappableEnum()
+@MappableEnum(defaultValue: 'unknown')
 enum AndroidDeviceType {
   @MappableValue('android')
   android,
+
+  @MappableValue('unknown')
+  unknown;
 }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/cat_type.dart
@@ -6,8 +6,11 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'cat_type.mapper.dart';
 
-@MappableEnum()
+@MappableEnum(defaultValue: 'unknown')
 enum CatType {
   @MappableValue('Cat')
   cat,
+
+  @MappableValue('unknown')
+  unknown;
 }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/dog_type.dart
@@ -6,8 +6,11 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'dog_type.mapper.dart';
 
-@MappableEnum()
+@MappableEnum(defaultValue: 'unknown')
 enum DogType {
   @MappableValue('Dog')
   dog,
+
+  @MappableValue('unknown')
+  unknown;
 }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/human_type.dart
@@ -6,8 +6,11 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'human_type.mapper.dart';
 
-@MappableEnum()
+@MappableEnum(defaultValue: 'unknown')
 enum HumanType {
   @MappableValue('Human')
   human,
+
+  @MappableValue('unknown')
+  unknown;
 }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/ios_device_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/expected_files/models/ios_device_type.dart
@@ -6,8 +6,11 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'ios_device_type.mapper.dart';
 
-@MappableEnum()
+@MappableEnum(defaultValue: 'unknown')
 enum IosDeviceType {
   @MappableValue('ios')
   ios,
+
+  @MappableValue('unknown')
+  unknown;
 }


### PR DESCRIPTION
Dart Mappable does not generate a toJson method for enums, instead generating a toValue method. There are no plans to change this. API client generators like Retrofit rely on detecting a toJson method to determine whether to use the enums name value or a serialized value.

This commit adds a toJson method to all enums.

`unknownEnumValue` functionality is also implemented fully.

