### PR TITLE
Exit when parser is finished

### DIFF
--- a/swagger_parser/bin/swagger_parser.dart
+++ b/swagger_parser/bin/swagger_parser.dart
@@ -46,6 +46,7 @@ Future<void> main(List<String> arguments) async {
       successSchemasCount: successSchemasCount,
       schemesCount: configs.length,
     );
+    exit(0);
   } on Exception catch (e) {
     exitWithError('Failed to generate files.\n$e');
   }


### PR DESCRIPTION
Apparently dart scripts wont exit automatically when they reach the end of their main function. Adding `exit(0)` fixes the issue.

I needed this so I can invoke the parser generator in a script without it hanging. 

Or maybe I'm doing something wrong? But it seemed simple enough, so I figured I'd just PR and let you decide. Thanks!