### PR TITLE
fix: Rename `squash_clients` to `merge_clients` on the README

### DIFF
--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -153,7 +153,7 @@ For multiple schemes:
 swagger_parser:
   # <...> Set default parameters for all schemes.
   output_directory: lib/api
-  squash_clients: true
+  merge_clients: true
 
   # Optional. You can pass a list of schemes. 
   # Each schema inherits the parameters described in swagger_parser,


### PR DESCRIPTION
This changed was introduced in [version 1.16.0](https://pub.dev/packages/swagger_parser/changelog#1160), but the documentation was not updated.