### PR TITLE
typedef_json_serializable_fix

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.24.2
+- Fixes `typedef` transparency which results in import errors when generating `json_serializable` classes
+  read more details here https://github.com/google/json_serializable.dart/issues/1124
+
 ## 1.24.1
 - Remove duplicate parameters in dataclass([#322](https://github.com/Carapacik/swagger_parser/issues/322))
 

--- a/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
@@ -17,7 +17,7 @@ String dartTypeDefTemplate(
   if (type == null) {
     return '';
   }
-  return '${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${import != null ? "import '${import.toSnake}.dart';\n\n" : ''}'
+  return '${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${import != null ? "import '${import.toSnake}.dart';\nexport '${import.toSnake}.dart';\n\n" : ''}'
       '${descriptionComment(dataClass.description)}'
       'typedef $className = ${type.toSuitableType(ProgrammingLanguage.dart)};\n';
 }

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.24.1
+version: 1.24.2
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 topics:
   - swagger

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -2094,6 +2094,7 @@ typedef BooleanList = List<bool>;
 ''';
       const expectedContent2 = '''
 import 'another.dart';
+export 'another.dart';
 
 typedef AnotherValue = Another;
 ''';


### PR DESCRIPTION
Fixes `typedefs` being transparent and causing import issues for json_serializable
https://github.com/google/json_serializable.dart/issues/1124