### PR TITLE
deduplicate by name

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.24.3
+- Fixes `allOf` case when a mix of `ref` and `properties` could unintentionally result in naming overlap
+  now we are deduplicating properties by name
+
 ## 1.24.2
 - Fixes `typedef` transparency which results in import errors when generating `json_serializable` classes
   read more details here https://github.com/google/json_serializable.dart/issues/1124

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.24.2
+version: 1.24.3
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 topics:
   - swagger

--- a/swagger_parser/test/e2e/tests/basic/all_of.3.0/all_of.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/all_of.3.0/all_of.3.0.json
@@ -62,7 +62,7 @@
                                        }
                                     },
                                     "nextCursor":{
-                                       "type":"string",
+                                       "type":"number",
                                        "nullable":true,
                                        "example":"01AN4Z07BY"
                                     }

--- a/swagger_parser/test/e2e/tests/basic/all_of.3.0/expected_files/models/get_users_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of.3.0/expected_files/models/get_users_response.dart
@@ -13,7 +13,7 @@ part 'get_users_response.g.dart';
 @Freezed()
 class GetUsersResponse with _$GetUsersResponse {
   const factory GetUsersResponse({
-    required String? nextCursor,
+    required num? nextCursor,
     required String? previousCursor,
     required List<UserDto> data,
   }) = _GetUsersResponse;


### PR DESCRIPTION
In case of heavily relying on `anyOf` it could result in a mixed stack of different refs and properties there is some chance that combined props will overlap by name.

This PR addresses the issue with deduplicating them by name.

Check test file for deatils

```
"responses":{
               "200":{
                  "description":"",
                  "content":{
                     "application/json":{
                        "schema":{
                           "allOf":[
                              {
                                 "$ref":"#/components/schemas/CursorPaginatedDto"
                              },
                              {
                                 "properties":{
                                    "data":{
                                       "type":"array",
                                       "items":{
                                          "$ref":"#/components/schemas/UserDto"
                                       }
                                    },
                                    "nextCursor":{
                                       "type":"number",
                                       "nullable":true,
                                       "example":"01AN4Z07BY"
                                    }
                                 },
                                 "required":[
                                    "data",
                                    "nextCursor"
                                 ]
                              }
                           ]
                        }
                     }
                  }
               }
            },
```

in this case we are redefining `nextCursor` from `CursorPaginatedDto`
```
"nextCursor":{
    "type":"string",
    "nullable":true,
    "example":"01AN4Z07BY"
}
```

with similarly named property but with a `number` type

```
"nextCursor":{
    "type":"number",
    "nullable":true,
    "example":"01AN4Z07BY"
}
```

Without this fix resulting object will have 2 props `nextCursor` which leads to analyzer errors