### PR TITLE
Support optional key

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -716,7 +716,9 @@ class OpenApiParser {
           propertyValue,
           name: propertyName,
           additionalName: additionalName,
-          isRequired: isRequired || hasAllOfKey || hasDefaultKey,
+          isRequired: (_apiInfo.schemaVersion == OAS.v2 && !config.useXNullable)
+              ? isRequired
+              : isRequired || hasAllOfKey || hasDefaultKey,
         );
 
         var validation = propertyValue;

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -117,6 +117,19 @@ void main() {
         schemaFileName: 'swagger.yaml',
       );
     });
+
+    test('no_required_params', () async {
+      await e2eTest(
+        'no_required_params',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
   });
 
   group('basic', () {

--- a/swagger_parser/test/e2e/tests/basic/additional_properties_class.3.0/additional_properties_class.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/additional_properties_class.3.0/additional_properties_class.3.0.json
@@ -14,7 +14,10 @@
               "type": "object"
             }
           }
-        }
+        },
+        "required": [
+          "data"
+        ]
       },
       "ExampleParsable": {
         "type": "object",
@@ -27,7 +30,10 @@
               "$ref": "#/definitions/Example"
             }
           }
-        }
+        },
+        "required": [
+          "data"
+        ]
       }
     }
   }

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/basic_requests.2.0.json
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.2.0/basic_requests.2.0.json
@@ -128,7 +128,12 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "password"
+      ]
     },
     "UserInfoDto": {
       "type": "object",
@@ -143,7 +148,12 @@
           "type": "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "phone"
+      ]
     }
   }
 }

--- a/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/basic_requests.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/basic_requests.3.0/basic_requests.3.0.json
@@ -120,7 +120,12 @@
               "password": {
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "email",
+              "name",
+              "password"
+            ]
           }
         ]
       },
@@ -138,7 +143,12 @@
               "phone": {
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "email",
+              "name",
+              "phone"
+            ]
           }
         ]
       }

--- a/swagger_parser/test/e2e/tests/basic/basic_types_class.2.0/basic_types_class.2.0.json
+++ b/swagger_parser/test/e2e/tests/basic/basic_types_class.2.0/basic_types_class.2.0.json
@@ -64,7 +64,23 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "integer1",
+        "float1",
+        "double1",
+        "string1",
+        "number1",
+        "string2",
+        "string3",
+        "string4",
+        "string5",
+        "file1",
+        "bool1",
+        "object1",
+        "array1",
+        "array2"
+      ]
     }
   }
 }

--- a/swagger_parser/test/e2e/tests/basic/basic_types_class.3.0/basic_types_class.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/basic_types_class.3.0/basic_types_class.3.0.json
@@ -73,7 +73,24 @@
             "type": "array",
             "default": []
           }
-        }
+        },
+        "required": [
+          "integer1",
+          "float1",
+          "double1",
+          "string1",
+          "number1",
+          "string2",
+          "string3",
+          "string4",
+          "string5",
+          "file1",
+          "bool1",
+          "object1",
+          "array1",
+          "array2",
+          "arrayWithDefault"
+        ]
       }
     }
   }

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/discriminated_one_of.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0/discriminated_one_of.3.0.json
@@ -34,7 +34,10 @@
               }
             }
           }
-        }
+        },
+        "required": [
+          "members"
+        ]
       },
       "Cat": {
         "type": "object",

--- a/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/discriminated_one_of.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/discriminated_one_of.3.0_mappable/discriminated_one_of.3.0.json
@@ -34,7 +34,10 @@
               }
             }
           }
-        }
+        },
+        "required": [
+          "members"
+        ]
       },
       "Cat": {
         "type": "object",

--- a/swagger_parser/test/e2e/tests/basic/enum_class/enum_class.json
+++ b/swagger_parser/test/e2e/tests/basic/enum_class/enum_class.json
@@ -21,7 +21,10 @@
             },
             "collectionFormat": "multi"
           }
-        }
+        },
+        "required": [
+          "status"
+        ]
       }
     }
   }

--- a/swagger_parser/test/e2e/tests/basic/of_like_class.3.1/expected_files/models/one_of_element.dart
+++ b/swagger_parser/test/e2e/tests/basic/of_like_class.3.1/expected_files/models/one_of_element.dart
@@ -12,19 +12,19 @@ part 'one_of_element.g.dart';
 @Freezed()
 class OneOfElement with _$OneOfElement {
   const factory OneOfElement({
-    required EnumClass allClass,
-    required EnumClass oneClass,
-    required int allType,
-    required DateTime anyType,
     required EnumClass? nullableButRequiredClass,
     required List<int>? requiredNullableListNonNullItems,
     required List<int?>? requiredNullableListNullableItems,
+    @Default(EnumClass.value1) EnumClass anyClass,
+    @Default([]) List<EnumClass> oneType,
     @Default([]) List<EnumClass>? nullableType,
+    EnumClass? allClass,
+    EnumClass? oneClass,
+    int? allType,
+    DateTime? anyType,
     EnumClass? nullableClass,
     List<int>? nullableListNonNullItems,
     List<int?>? nullableListNullableItems,
-    @Default(EnumClass.value1) EnumClass anyClass,
-    @Default([]) List<EnumClass> oneType,
   }) = _OneOfElement;
 
   factory OneOfElement.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/basic/reference_types_class.2.0/reference_types_class.2.0.json
+++ b/swagger_parser/test/e2e/tests/basic/reference_types_class.2.0/reference_types_class.2.0.json
@@ -10,7 +10,11 @@
         "another": {
           "$ref": "#/definitions/AnotherClass"
         }
-      }
+      },
+      "required": [
+        "id",
+        "another"
+      ]
     },
     "AnotherClass": {
       "type": "object",
@@ -21,7 +25,11 @@
         "name": {
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
     }
   }
 }

--- a/swagger_parser/test/e2e/tests/basic/reference_types_class.3.0/reference_types_class.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/reference_types_class.3.0/reference_types_class.3.0.json
@@ -14,7 +14,11 @@
               "another": {
                 "$ref": "#/components/schemas/AnotherClass"
               }
-            }
+            },
+            "required": [
+              "id",
+              "another"
+            ]
           }
         ]
       },
@@ -29,7 +33,11 @@
               "name": {
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "id",
+              "name"
+            ]
           }
         ]
       }

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/new_pet_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/new_pet_dto.dart
@@ -12,16 +12,16 @@ part 'new_pet_dto.g.dart';
 class NewPetDto {
   const NewPetDto({
     required this.name,
-    required this.tag,
-    required this.action,
+    this.tag,
+    this.action,
   });
 
   factory NewPetDto.fromJson(Map<String, Object?> json) =>
       _$NewPetDtoFromJson(json);
 
   final String name;
-  final String tag;
-  final NewPetDtoActionDto action;
+  final String? tag;
+  final NewPetDtoActionDto? action;
 
   Map<String, Object?> toJson() => _$NewPetDtoToJson(this);
 }

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/pet_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/pet_dto.dart
@@ -12,16 +12,16 @@ part 'pet_dto.g.dart';
 class PetDto {
   const PetDto({
     required this.name,
-    required this.tag,
-    required this.action,
     required this.id,
+    this.tag,
+    this.action,
   });
 
   factory PetDto.fromJson(Map<String, Object?> json) => _$PetDtoFromJson(json);
 
   final String name;
-  final String tag;
-  final NewPetDtoActionDto action;
+  final String? tag;
+  final NewPetDtoActionDto? action;
   final int id;
 
   Map<String, Object?> toJson() => _$PetDtoToJson(this);

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/object1_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/object1_dto.dart
@@ -14,7 +14,7 @@ part 'object1_dto.g.dart';
 class Object1Dto with _$Object1Dto {
   const factory Object1Dto({
     @JsonKey(name: 'p1_class') required P1ClassDto p1Class,
-    @JsonKey(name: 'p2_enum') required P2EnumDto p2Enum,
+    @JsonKey(name: 'p2_enum') P2EnumDto? p2Enum,
   }) = _Object1Dto;
 
   factory Object1Dto.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/openapi.yaml
@@ -38,6 +38,8 @@ paths:
                     test:
                       type: string
                       format: date-time
+                  required:
+                    - test
                 p2_enum:
                   type: string
                   enum:
@@ -71,6 +73,8 @@ paths:
                     test:
                       type: string
                       format: date-time
+                  required:
+                    - test
                 p2_enum:
                   type: string
                   enum:

--- a/swagger_parser/test/e2e/tests/basic/use_freezed3.3.0/use_freezed3.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/use_freezed3.3.0/use_freezed3.3.0.json
@@ -66,7 +66,23 @@
               }
             }
           }
-        }
+        },
+        "required": [
+          "integer1",
+          "float1",
+          "double1",
+          "string1",
+          "number1",
+          "string2",
+          "string3",
+          "string4",
+          "string5",
+          "file1",
+          "bool1",
+          "object1",
+          "array1",
+          "array2"
+        ]
       }
     }
   }

--- a/swagger_parser/test/e2e/tests/basic/wrapping_collections.2.0/wrapping_collections.2.0.json
+++ b/swagger_parser/test/e2e/tests/basic/wrapping_collections.2.0/wrapping_collections.2.0.json
@@ -22,7 +22,12 @@
           }
         }
       },
-      "additionalProperties": {}
+      "additionalProperties": {},
+      "required": [
+        "type",
+        "instance",
+        "errors"
+      ]
     },
     "DataClass2": {
       "type": "object",
@@ -49,7 +54,11 @@
           }
         }
       },
-      "additionalProperties": {}
+      "additionalProperties": {},
+      "required": [
+        "title",
+        "errors"
+      ]
     }
   }
 }

--- a/swagger_parser/test/e2e/tests/basic/wrapping_collections.3.0/wrapping_collections.3.0.json
+++ b/swagger_parser/test/e2e/tests/basic/wrapping_collections.3.0/wrapping_collections.3.0.json
@@ -25,7 +25,10 @@
             }
           }
         },
-        "additionalProperties": {}
+        "additionalProperties": {},
+        "required": [
+          "errors"
+        ]
       },
       "DataClass2": {
         "type": "object",
@@ -53,7 +56,10 @@
             }
           }
         },
-        "additionalProperties": {}
+        "additionalProperties": {},
+        "required": [
+          "errors"
+        ]
       }
     }
   }

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/models/object0_dto.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/models/object0_dto.dart
@@ -10,7 +10,7 @@ part 'object0_dto.g.dart';
 @Freezed()
 class Object0Dto with _$Object0Dto {
   const factory Object0Dto({
-    required DateTime test,
+    DateTime? test,
   }) = _Object0Dto;
 
   factory Object0Dto.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/models/object1_dto.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/models/object1_dto.dart
@@ -14,7 +14,7 @@ part 'object1_dto.g.dart';
 class Object1Dto with _$Object1Dto {
   const factory Object1Dto({
     @JsonKey(name: 'p1_class') required P1ClassDto p1Class,
-    @JsonKey(name: 'p2_enum') required P2EnumDto p2Enum,
+    @JsonKey(name: 'p2_enum') P2EnumDto? p2Enum,
   }) = _Object1Dto;
 
   factory Object1Dto.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/models/p1_class_dto.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/models/p1_class_dto.dart
@@ -10,7 +10,7 @@ part 'p1_class_dto.g.dart';
 @Freezed()
 class P1ClassDto with _$P1ClassDto {
   const factory P1ClassDto({
-    required DateTime test,
+    DateTime? test,
   }) = _P1ClassDto;
 
   factory P1ClassDto.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/nullable_enum_in_object.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/nullable_enum_in_object.dart
@@ -12,7 +12,7 @@ part 'nullable_enum_in_object.g.dart';
 @Freezed()
 class NullableEnumInObject with _$NullableEnumInObject {
   const factory NullableEnumInObject({
-    required Fruits? fruits,
+    Fruits? fruits,
   }) = _NullableEnumInObject;
 
   factory NullableEnumInObject.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/models/object1.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_properties/expected_files/models/object1.dart
@@ -10,7 +10,7 @@ part 'object1.g.dart';
 @Freezed()
 class Object1 with _$Object1 {
   const factory Object1({
-    required String street,
+    String? street,
   }) = _Object1;
 
   factory Object1.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/models/object0.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/models/object0.dart
@@ -10,7 +10,7 @@ part 'object0.g.dart';
 @Freezed()
 class Object0 with _$Object0 {
   const factory Object0({
-    required String street,
+    String? street,
   }) = _Object0;
 
   factory Object0.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/models/object1.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref/expected_files/models/object1.dart
@@ -10,7 +10,7 @@ part 'object1.g.dart';
 @Freezed()
 class Object1 with _$Object1 {
   const factory Object1({
-    required String street,
+    String? street,
   }) = _Object1;
 
   factory Object1.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/no_required_params/expected_files/clients/api_client.dart
+++ b/swagger_parser/test/e2e/tests/no_required_params/expected_files/clients/api_client.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/option.dart';
+
+part 'api_client.g.dart';
+
+@RestApi()
+abstract class ApiClient {
+  factory ApiClient(Dio dio, {String? baseUrl}) = _ApiClient;
+
+  @GET('/api/v1/category/')
+  Future<void> apiV1CategoryList({
+    @Query('option') Option? option,
+  });
+}

--- a/swagger_parser/test/e2e/tests/no_required_params/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/no_required_params/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/api_client.dart';
+// Data classes
+export 'models/option.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/no_required_params/expected_files/models/option.dart
+++ b/swagger_parser/test/e2e/tests/no_required_params/expected_files/models/option.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'option.freezed.dart';
+part 'option.g.dart';
+
+@Freezed()
+class Option with _$Option {
+  const factory Option({
+    @JsonKey(name: 'required_id') required int requiredId,
+    @JsonKey(name: 'required_name') required String requiredName,
+    @JsonKey(name: 'required_nullable_id') required int? requiredNullableId,
+    @JsonKey(name: 'required_nullable_name')
+    required String? requiredNullableName,
+    @JsonKey(name: 'optional_id') int? optionalId,
+    @JsonKey(name: 'optional_name') String? optionalName,
+  }) = _Option;
+
+  factory Option.fromJson(Map<String, Object?> json) => _$OptionFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/no_required_params/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/no_required_params/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/api_client.dart';
+
+///  `v0.0.0 (v1)`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '0.0.0 (v1)';
+
+  ApiClient? _api;
+
+  ApiClient get api => _api ??= ApiClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/no_required_params/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/no_required_params/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: 3.1.0
+info:
+  title: ''
+  version: 0.0.0 (v1)
+paths:
+  /api/v1/category/:
+    get:
+      operationId: api_v1_category_list
+      parameters:
+        - in: query
+          name: option
+          schema:
+            $ref: '#/components/schemas/Option'
+      tags:
+        - api
+      responses:
+        '204':
+          description: ''
+components:
+  schemas:
+    Option:
+      type: object
+      properties:
+        required_id:
+          type: integer
+        required_name:
+          type: string
+        required_nullable_id:
+          type: integer
+          nullable: true
+        required_nullable_name:
+          type: string
+          nullable: true 
+        optional_id:
+          type: integer
+        optional_name:
+          type: string
+      required:
+        - required_id
+        - required_name
+        - required_nullable_id
+        - required_nullable_name

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/category.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/category.dart
@@ -11,8 +11,8 @@ part 'category.g.dart';
 @Freezed()
 class Category with _$Category {
   const factory Category({
-    required int id,
-    required String name,
+    int? id,
+    String? name,
   }) = _Category;
 
   factory Category.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/pet.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/pet.dart
@@ -15,10 +15,10 @@ part 'pet.g.dart';
 @Freezed()
 class Pet with _$Pet {
   const factory Pet({
-    required Category category,
     required String name,
     required List<String> photoUrls,
     int? id,
+    Category? category,
     List<Tag>? tags,
 
     /// pet status in the store

--- a/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/get_test2_response.dart
+++ b/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/get_test2_response.dart
@@ -12,7 +12,7 @@ class GetTest2Response with _$GetTest2Response {
   const factory GetTest2Response({
     required List<String> list,
     required String? name,
-    required String lastname,
+    String? lastname,
   }) = _GetTest2Response;
 
   factory GetTest2Response.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/object0.dart
+++ b/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/object0.dart
@@ -12,7 +12,7 @@ class Object0 with _$Object0 {
   const factory Object0({
     required List<dynamic> list,
     required String? name,
-    required String lastname,
+    String? lastname,
   }) = _Object0;
 
   factory Object0.fromJson(Map<String, Object?> json) =>

--- a/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/object1.dart
+++ b/swagger_parser/test/e2e/tests/request_unnamed_types/expected_files/models/object1.dart
@@ -13,9 +13,9 @@ part 'object1.g.dart';
 class Object1 with _$Object1 {
   const factory Object1({
     required List<Example> list1,
-    required List<Map<String, Example>> list2,
     required String? name,
-    required String lastname,
+    List<Map<String, Example>>? list2,
+    String? lastname,
   }) = _Object1;
 
   factory Object1.fromJson(Map<String, Object?> json) =>


### PR DESCRIPTION
Thanks for the great library! 

fix #257 #307

### about fix

The current implementation treats the cases where the `nullable` option is not specified and `false` as `required: true`. However, this limitation creates a “can't omit unnecessary keys” problem. The purpose of this PR is to solve this.

I created a commit and noticed that it affects the test cases. In most `/basic` test cases, the `required` option is probably missing. For this reason, I added keys to `required` section.
On the other hand, the following case appeared to want to check if the `required` option was set.

* e2e test cases
* `of_like_class.3.1`
* `replacement_rules.2.0`
* `replacement_rules.3.1`

Therefore, the impact of this PR-induced correction is reflected.

### my motivation

In the following scheme, I would like to make the `optional_id` and `optional_name` omitted.

```yaml
openapi: 3.1.0
info:
  title: ''
  version: 0.0.0 (v1)
paths:
  /api/v1/category/:
    get:
      operationId: api_v1_category_list
      parameters:
        - in: query
          name: option
          schema:
            $ref: '#/components/schemas/Option'
      tags:
        - api
      responses:
        '204':
          description: ''
components:
  schemas:
    Option:
      type: object
      properties:
        required_id:
          type: integer
        required_name:
          type: string
        required_nullable_id:
          type: integer
          nullable: true
        required_nullable_name:
          type: string
          nullable: true 
        optional_id:
          type: integer
        optional_name:
          type: string
      required:
        - required_id
        - required_name
        - required_nullable_id
        - required_nullable_name
```

I added test case at `no_required_params/expected_files/clients/api_client.dart`.