### PR TITLE
Support using MultipartFile instead of File

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.25.0
+- Allow using `MultipartFile` instead of `File` in multipart requests, to support usage on web.
+
 ## 1.24.6
 - proper handling of binary responses aka file downloads, picked up from https://github.com/trevorwang/retrofit.dart/issues/503
 

--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -145,6 +145,10 @@ swagger_parser:
   # Optional (dart & freezed only). Set 'true' to use Freezed 3.x code generation syntax.
   # Set 'false' to maintain compatibility with Freezed 2.x.
   use_freezed3: false
+
+  # DART ONLY
+  # Optional. Set `true` to use MultipartFile instead of File as argument type for file parameters.
+  use_multipart_file: false
 ```
 
 For multiple schemes:

--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -36,6 +36,7 @@ class SWPConfig {
     this.generateValidator = false,
     this.useXNullable = false,
     this.useFreezed3 = false,
+    this.useMultipartFile = false,
   });
 
   /// Internal constructor of [SWPConfig]
@@ -66,6 +67,7 @@ class SWPConfig {
     required this.generateValidator,
     required this.useXNullable,
     required this.useFreezed3,
+    required this.useMultipartFile,
   });
 
   /// Creates a [SWPConfig] from [YamlMap].
@@ -214,6 +216,9 @@ class SWPConfig {
     final useFreezed3 =
         yamlMap['use_freezed3'] as bool? ?? rootConfig?.useFreezed3;
 
+    final useMultipartFile =
+        yamlMap['use_multipart_file'] as bool? ?? rootConfig?.useMultipartFile;
+
     // Default config
     final dc = SWPConfig(name: name, outputDirectory: outputDirectory);
 
@@ -246,6 +251,7 @@ class SWPConfig {
       generateValidator: generateValidator ?? dc.generateValidator,
       useXNullable: useXNullable ?? dc.useXNullable,
       useFreezed3: useFreezed3 ?? dc.useFreezed3,
+      useMultipartFile: useMultipartFile ?? dc.useMultipartFile,
     );
   }
 
@@ -359,6 +365,11 @@ class SWPConfig {
   /// Set `false` to maintain compatibility with Freezed 2.x
   final bool useFreezed3;
 
+  /// DART ONLY
+  /// Optional. Set `true` to use MultipartFile instead of File as argument type
+  /// for file parameters.
+  final bool useMultipartFile;
+
   /// Convert [SWPConfig] to [GeneratorConfig]
   GeneratorConfig toGeneratorConfig() {
     return GeneratorConfig(
@@ -381,6 +392,7 @@ class SWPConfig {
       replacementRules: replacementRules,
       generateValidator: generateValidator,
       useFreezed3: useFreezed3,
+      useMultipartFile: useMultipartFile,
     );
   }
 

--- a/swagger_parser/lib/src/generator/config/generator_config.dart
+++ b/swagger_parser/lib/src/generator/config/generator_config.dart
@@ -25,6 +25,7 @@ class GeneratorConfig {
     this.replacementRules = const [],
     this.generateValidator = false,
     this.useFreezed3 = false,
+    this.useMultipartFile = false,
   });
 
   /// Optional. Set API name for folder and export file
@@ -113,4 +114,9 @@ class GeneratorConfig {
 
   /// Optional. Set `true` to use freezed v3 if jsonSerializer is freezed.
   final bool useFreezed3;
+
+  /// DART ONLY
+  /// Optional. Set `true` to use MultipartFile instead of File as argument type
+  /// for file parameters.
+  final bool useMultipartFile;
 }

--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -31,6 +31,7 @@ final class FillController {
           markFilesAsGenerated: config.markFilesAsGenerated,
           generateValidator: config.generateValidator,
           useFreezed3: config.useFreezed3,
+          useMultipartFile: config.useMultipartFile,
         ),
       );
 
@@ -53,6 +54,7 @@ final class FillController {
         extrasParameterByDefault: config.extrasParameterByDefault,
         dioOptionsParameterByDefault: config.dioOptionsParameterByDefault,
         originalHttpResponse: config.originalHttpResponse,
+        useMultipartFile: config.useMultipartFile,
       ),
     );
   }

--- a/swagger_parser/lib/src/generator/generator/generator_processor.dart
+++ b/swagger_parser/lib/src/generator/generator/generator_processor.dart
@@ -28,7 +28,6 @@ class GenProcessor {
     );
 
     final parser = OpenApiParser(parserConfig);
-
     final generatorConfig = config.toGeneratorConfig();
     final info = parser.openApiInfo;
     final restClients = parser.parseRestClients();

--- a/swagger_parser/lib/src/generator/model/programming_language.dart
+++ b/swagger_parser/lib/src/generator/model/programming_language.dart
@@ -48,6 +48,7 @@ enum ProgrammingLanguage {
     required bool markFilesAsGenerated,
     required bool generateValidator,
     required bool useFreezed3,
+    required bool useMultipartFile,
   }) {
     switch (this) {
       case dart:
@@ -64,6 +65,7 @@ enum ProgrammingLanguage {
             return dartTypeDefTemplate(
               dataClass,
               markFileAsGenerated: markFilesAsGenerated,
+              useMultipartFile: useMultipartFile,
             );
           }
           return switch (jsonSerializer) {
@@ -72,14 +74,17 @@ enum ProgrammingLanguage {
                 markFileAsGenerated: markFilesAsGenerated,
                 generateValidator: generateValidator,
                 isV3: useFreezed3,
+                useMultipartFile: useMultipartFile,
               ),
             JsonSerializer.jsonSerializable => dartJsonSerializableDtoTemplate(
                 dataClass,
                 markFileAsGenerated: markFilesAsGenerated,
+                useMultipartFile: useMultipartFile,
               ),
             JsonSerializer.dartMappable => dartDartMappableDtoTemplate(
                 dataClass,
                 markFileAsGenerated: markFilesAsGenerated,
+                useMultipartFile: useMultipartFile,
               ),
           };
         }
@@ -111,6 +116,7 @@ enum ProgrammingLanguage {
     String name, {
     required bool markFilesAsGenerated,
     required String defaultContentType,
+    required bool useMultipartFile,
     bool extrasParameterByDefault = false,
     bool dioOptionsParameterByDefault = false,
     bool originalHttpResponse = false,
@@ -124,6 +130,7 @@ enum ProgrammingLanguage {
             extrasParameterByDefault: extrasParameterByDefault,
             dioOptionsParameterByDefault: dioOptionsParameterByDefault,
             originalHttpResponse: originalHttpResponse,
+            useMultipartFile: useMultipartFile,
           ),
         kotlin => kotlinRetrofitClientTemplate(
             restClient: restClient,

--- a/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
@@ -11,6 +11,7 @@ import 'dart_import_dto_template.dart';
 String dartDartMappableDtoTemplate(
   UniversalComponentClass dataClass, {
   required bool markFileAsGenerated,
+  required bool useMultipartFile,
 }) {
   final className = dataClass.name.toPascal;
 
@@ -37,7 +38,7 @@ ${descriptionComment(dataClass.description)}@MappableClass(${() {
 class $className ${parent != null ? "extends $parent " : ""}with ${className}Mappable {
 
 ${indentation(2)}const $className(${getParameters(dataClass)});
-${getFields(dataClass)}
+${getFields(dataClass, useMultipartFile: useMultipartFile)}
 ${getDiscriminatorConvenienceMethods(dataClass)}
 ${indentation(2)}static $className fromJson(Map<String, dynamic> json) => ${className}Mapper.ensureInitialized().decodeMap<$className>(json);
 }
@@ -80,27 +81,28 @@ String getParameters(UniversalComponentClass dataClass) {
   }
 }
 
-String getFields(UniversalComponentClass dataClass) {
+String getFields(UniversalComponentClass dataClass,
+    {required bool useMultipartFile}) {
   // if this class has discriminated values, don't populate the discriminator field
   // in the parent class
   final parameters = dataClass.parameters
       .where((it) => it.name != dataClass.discriminator?.propertyName)
       .toList();
   if (parameters.isNotEmpty) {
-    return '${_fieldsToString(parameters)}\n';
+    return '${_fieldsToString(parameters, useMultipartFile)}\n';
   } else {
     return '';
   }
 }
 
-String _fieldsToString(List<UniversalType> parameters) {
+String _fieldsToString(List<UniversalType> parameters, bool useMultipartFile) {
   final sortedByRequired = Set<UniversalType>.from(
     parameters.sorted((a, b) => a.compareTo(b)),
   );
   return sortedByRequired
       .mapIndexed(
         (i, e) =>
-            '${_jsonKey(e)}${indentation(2)}final ${e.toSuitableType(ProgrammingLanguage.dart)} ${e.name};',
+            '${_jsonKey(e)}${indentation(2)}final ${e.toSuitableType(ProgrammingLanguage.dart, useMultipartFile: useMultipartFile)} ${e.name};',
       )
       .join('\n');
 }

--- a/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
@@ -10,10 +10,11 @@ import '../model/programming_language.dart';
 String dartJsonSerializableDtoTemplate(
   UniversalComponentClass dataClass, {
   required bool markFileAsGenerated,
+  required bool useMultipartFile,
 }) {
   final className = dataClass.name.toPascal;
   return '''
-${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${ioImport(dataClass)}import 'package:json_annotation/json_annotation.dart';
+${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${ioImport(dataClass.parameters, useMultipartFile: useMultipartFile)}import 'package:json_annotation/json_annotation.dart';
 ${dartImports(imports: dataClass.imports)}
 part '${dataClass.name.toSnake}.g.dart';
 
@@ -22,19 +23,21 @@ class $className {
   const $className(${dataClass.parameters.isNotEmpty ? '{' : ''}${_parametersInConstructor(dataClass.parameters)}${dataClass.parameters.isNotEmpty ? '\n  }' : ''});
   
   factory $className.fromJson(Map<String, Object?> json) => _\$${className}FromJson(json);
-  ${_parametersInClass(dataClass.parameters)}${dataClass.parameters.isNotEmpty ? '\n' : ''}
+  ${_parametersInClass(dataClass.parameters, useMultipartFile)}${dataClass.parameters.isNotEmpty ? '\n' : ''}
   Map<String, Object?> toJson() => _\$${className}ToJson(this);
 }
 ''';
 }
 
-String _parametersInClass(Set<UniversalType> parameters) => parameters
-    .mapIndexed(
-      (i, e) =>
-          '\n${i != 0 && (e.description?.isNotEmpty ?? false) ? '\n' : ''}${descriptionComment(e.description, tab: '  ')}'
-          '${_jsonKey(e)}  final ${e.toSuitableType(ProgrammingLanguage.dart)} ${e.name};',
-    )
-    .join();
+String _parametersInClass(
+        Set<UniversalType> parameters, bool useMultipartFile) =>
+    parameters
+        .mapIndexed(
+          (i, e) =>
+              '\n${i != 0 && (e.description?.isNotEmpty ?? false) ? '\n' : ''}${descriptionComment(e.description, tab: '  ')}'
+              '${_jsonKey(e)}  final ${e.toSuitableType(ProgrammingLanguage.dart, useMultipartFile: useMultipartFile)} ${e.name};',
+        )
+        .join();
 
 String _parametersInConstructor(Set<UniversalType> parameters) {
   final sortedByRequired = Set<UniversalType>.from(

--- a/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
@@ -7,10 +7,8 @@ import '../../utils/type_utils.dart';
 import '../model/programming_language.dart';
 
 /// Provides template for generating dart typedefs using JSON serializable
-String dartTypeDefTemplate(
-  UniversalComponentClass dataClass, {
-  required bool markFileAsGenerated,
-}) {
+String dartTypeDefTemplate(UniversalComponentClass dataClass,
+    {required bool markFileAsGenerated, required bool useMultipartFile}) {
   final className = dataClass.name.toPascal;
   final type = dataClass.parameters.firstOrNull;
   final import = dataClass.imports.firstOrNull;
@@ -19,5 +17,5 @@ String dartTypeDefTemplate(
   }
   return '${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${import != null ? "import '${import.toSnake}.dart';\nexport '${import.toSnake}.dart';\n\n" : ''}'
       '${descriptionComment(dataClass.description)}'
-      'typedef $className = ${type.toSuitableType(ProgrammingLanguage.dart)};\n';
+      'typedef $className = ${type.toSuitableType(ProgrammingLanguage.dart, useMultipartFile: useMultipartFile)};\n';
 }

--- a/swagger_parser/lib/src/generator/templates/kotlin_moshi_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_moshi_dto_template.dart
@@ -22,7 +22,7 @@ String _parameters(Set<UniversalType> parameters) => parameters
     .map(
       (e) => '\n${descriptionComment(e.description, tab: '    ')}'
           '${e.jsonKey != null && e.name != e.jsonKey ? '    @Json("${protectJsonKey(e.jsonKey)}")\n' : ''}    '
-          'var ${e.name}: ${e.toSuitableType(ProgrammingLanguage.kotlin)}'
+          'var ${e.name}: ${e.toSuitableType(ProgrammingLanguage.kotlin, useMultipartFile: false)}'
           '${e.defaultValue != null ? ' = ${protectDefaultValue(e.defaultValue, type: e.type, dart: false)}' : ''},',
     )
     .join();

--- a/swagger_parser/lib/src/generator/templates/kotlin_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_retrofit_client_template.dart
@@ -47,14 +47,14 @@ String _toClientRequest(UniversalRequest request) {
   }
 
   sb.write(
-    ': ${request.returnType!.toSuitableType(ProgrammingLanguage.kotlin)}\n',
+    ': ${request.returnType!.toSuitableType(ProgrammingLanguage.kotlin, useMultipartFile: false)}\n',
   );
   return sb.toString();
 }
 
 String _toQueryParameter(UniversalRequestType parameter) =>
     '        @${parameter.parameterType.type}${parameter.name != null && !parameter.parameterType.isBody ? '("${parameter.name}")' : ''} '
-    '${parameter.type.name!.toCamel}: ${parameter.type.toSuitableType(ProgrammingLanguage.kotlin)}'
+    '${parameter.type.name!.toCamel}: ${parameter.type.toSuitableType(ProgrammingLanguage.kotlin, useMultipartFile: false)}'
     '${_defaultValue(parameter.type)}';
 
 /// return defaultValue if have

--- a/swagger_parser/lib/src/generator/templates/kotlin_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_typedef_template.dart
@@ -17,5 +17,5 @@ String kotlinTypeDefTemplate(
     return '';
   }
   return '${generatedFileComment(markFileAsGenerated: markFileAsGenerated, ignoreLints: false)}${descriptionComment(dataClass.description)}'
-      'typealias $className = ${type.toSuitableType(ProgrammingLanguage.kotlin)};\n';
+      'typealias $className = ${type.toSuitableType(ProgrammingLanguage.kotlin, useMultipartFile: false)};\n';
 }

--- a/swagger_parser/lib/src/parser/utils/type_utils.dart
+++ b/swagger_parser/lib/src/parser/utils/type_utils.dart
@@ -5,7 +5,8 @@ import 'dart_keywords.dart';
 /// Extension for utils
 extension StringTypeX on String {
   /// Convert string to dart type
-  String toDartType([String? format]) => switch (this) {
+  String toDartType({String? format, bool useMultipartFile = false}) =>
+      switch (this) {
         'integer' => 'int',
         'number' => switch (format) {
             'float' || 'double' => 'double',
@@ -14,11 +15,11 @@ extension StringTypeX on String {
             _ => 'num',
           },
         'string' => switch (format) {
-            'binary' => 'File',
+            'binary' => useMultipartFile ? 'List<MultipartFile>' : 'File',
             'date' || 'date-time' => 'DateTime',
             _ => 'String',
           },
-        'file' => 'File',
+        'file' => useMultipartFile ? 'List<MultipartFile>' : 'File',
         'boolean' => 'bool',
         // https://github.com/trevorwang/retrofit.dart/issues/631
         // https://github.com/Carapacik/swagger_parser/issues/110

--- a/swagger_parser/lib/src/utils/base_utils.dart
+++ b/swagger_parser/lib/src/utils/base_utils.dart
@@ -1,4 +1,3 @@
-import '../generator/model/programming_language.dart';
 import '../parser/swagger_parser_core.dart';
 import '../parser/utils/case_utils.dart';
 import 'type_utils.dart';
@@ -55,9 +54,11 @@ String? replaceNotEnglishLetter(String? text) {
 }
 
 /// Specially for File import
-String ioImport(UniversalComponentClass dataClass) => dataClass.parameters.any(
-      (p) => p.toSuitableType(ProgrammingLanguage.dart).startsWith('File'),
-    )
+String ioImport(
+  Set<UniversalType> parameters, {
+  required bool useMultipartFile,
+}) =>
+    parameters.any((p) => p.needsIoImport(useMultipartFile: useMultipartFile))
         ? "import 'dart:io';\n\n"
         : '';
 

--- a/swagger_parser/lib/src/utils/type_utils.dart
+++ b/swagger_parser/lib/src/utils/type_utils.dart
@@ -1,10 +1,19 @@
 import '../generator/model/programming_language.dart';
 import '../parser/swagger_parser_core.dart';
 
+final _fileTypeRegExp = RegExp(r'\bFile\b');
+
 /// Converts [UniversalType] to type from specified language
 extension UniversalTypeX on UniversalType {
+  bool needsIoImport({required bool useMultipartFile}) =>
+      _fileTypeRegExp.hasMatch(toSuitableType(ProgrammingLanguage.dart,
+          useMultipartFile: useMultipartFile));
+
   /// Converts [UniversalType] to concrete type of certain [ProgrammingLanguage]
-  String toSuitableType(ProgrammingLanguage lang) {
+  String toSuitableType(
+    ProgrammingLanguage lang, {
+    required bool useMultipartFile,
+  }) {
     final sb = StringBuffer();
 
     // Append all collection prefixes, e.g., "List<"
@@ -19,7 +28,8 @@ extension UniversalTypeX on UniversalType {
     String baseTypeName;
     switch (lang) {
       case ProgrammingLanguage.dart:
-        baseTypeName = type.toDartType(format);
+        baseTypeName =
+            type.toDartType(format: format, useMultipartFile: useMultipartFile);
       case ProgrammingLanguage.kotlin:
         baseTypeName = type.toKotlinType(format);
     }

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.24.6
+version: 1.25.0
 repository: https://github.com/Carapacik/swagger_parser/tree/main/swagger_parser
 topics:
   - swagger

--- a/swagger_parser/test/generator/rest_clients_test.dart
+++ b/swagger_parser/test/generator/rest_clients_test.dart
@@ -1179,6 +1179,124 @@ abstract class ClassNameClient {
       expect(filledContent.content, expectedContents);
     });
 
+    test('dart + retrofit with useMultipartFile = true', () async {
+      const restClient = UniversalRestClient(
+        name: 'ClassName',
+        imports: {'AnotherFile'},
+        requests: [
+          UniversalRequest(
+            name: 'sendMultiPart',
+            requestType: HttpRequestType.post,
+            route: '/send',
+            returnType: null,
+            contentType: 'multipart/form-data',
+            parameters: [
+              UniversalRequestType(
+                parameterType: HttpParameterType.header,
+                type: UniversalType(
+                  type: 'string',
+                  name: 'token',
+                  isRequired: true,
+                ),
+                name: 'Authorization',
+              ),
+              UniversalRequestType(
+                parameterType: HttpParameterType.part,
+                type: UniversalType(
+                  type: 'string',
+                  name: 'alex',
+                  isRequired: false,
+                  nullable: true,
+                ),
+                name: 'name',
+              ),
+              UniversalRequestType(
+                parameterType: HttpParameterType.part,
+                type: UniversalType(
+                  type: 'string',
+                  format: 'binary',
+                  name: 'file',
+                  isRequired: true,
+                ),
+                name: 'file',
+              ),
+              UniversalRequestType(
+                parameterType: HttpParameterType.part,
+                type: UniversalType(
+                  type: 'file',
+                  name: 'secondFile',
+                  isRequired: true,
+                ),
+                name: 'file2',
+              ),
+              UniversalRequestType(
+                parameterType: HttpParameterType.part,
+                type: UniversalType(
+                  type: 'boolean',
+                  name: 'parsed',
+                  isRequired: true,
+                ),
+                name: 'parsed-if',
+              ),
+            ],
+          ),
+          UniversalRequest(
+            name: 'singleEntity',
+            requestType: HttpRequestType.post,
+            route: '/single',
+            returnType: UniversalType(type: 'boolean', isRequired: true),
+            contentType: 'multipart/form-data',
+            parameters: [
+              UniversalRequestType(
+                parameterType: HttpParameterType.body,
+                type: UniversalType(
+                  type: 'AnotherFile',
+                  name: 'file',
+                  isRequired: true,
+                ),
+              ),
+            ],
+          ),
+        ],
+      );
+      const fillController = FillController(
+        config: GeneratorConfig(
+            name: '', outputDirectory: '', useMultipartFile: true),
+      );
+      final filledContent = fillController.fillRestClientContent(restClient);
+      const expectedContents = '''
+import 'dart:convert';
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/another_file.dart';
+
+part 'class_name_client.g.dart';
+
+@RestApi()
+abstract class ClassNameClient {
+  factory ClassNameClient(Dio dio, {String? baseUrl}) = _ClassNameClient;
+
+  @MultiPart()
+  @POST('/send')
+  Future<void> sendMultiPart({
+    @Header('Authorization') required String token,
+    @Part(name: 'file') required List<MultipartFile> file,
+    @Part(name: 'file2') required List<MultipartFile> secondFile,
+    @Part(name: 'parsed-if') required bool parsed,
+    @Part(name: 'name') String? alex,
+  });
+
+  @MultiPart()
+  @POST('/single')
+  Future<bool> singleEntity({
+    @Body() required AnotherFile file,
+  });
+}
+''';
+      expect(filledContent.content, expectedContents);
+    });
+
     test('kotlin + retrofit', () async {
       const restClient = UniversalRestClient(
         name: 'ClassName',


### PR DESCRIPTION
As far as I can see, this should be the only thing that could prevent using `swagger_parser` to generate clients for use with Flutter on the web.

EDIT: Oh, and it appears `retrofit` [only supports `List<MultipartFile>`](https://github.com/trevorwang/retrofit.dart/issues/464), which is why I used that as the type rather than simply `MultipartFile`