### PR TITLE
feat: allow filtering endpoints generation by tags

### DIFF
--- a/swagger_parser/README.md
+++ b/swagger_parser/README.md
@@ -1,10 +1,12 @@
 # Swagger Parser
+
 [![pub version](https://img.shields.io/pub/v/swagger_parser?logo=dart)](https://pub.dev/packages/swagger_parser)
 [![pub likes](https://img.shields.io/pub/likes/swagger_parser?logo=dart)](https://pub.dev/packages/swagger_parser)
 [![dart style](https://img.shields.io/badge/style-carapacik__lints%20-brightgreen?logo=dart)](https://pub.dev/packages/carapacik_lints)
 [![Star on Github](https://img.shields.io/github/stars/Carapacik/swagger_parser?logo=github)](https://github.com/Carapacik/swagger_parser)
 [![Last commit on Github](https://img.shields.io/github/last-commit/Carapacik/swagger_parser?logo=github)](https://github.com/Carapacik/swagger_parser)
 [![Tests](https://github.com/Carapacik/swagger_parser/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/Carapacik/swagger_parser/actions/workflows/tests.yml)
+
 ## Dart package that generates REST clients and data classes from OpenApi definition files or links
 
 ## Features
@@ -114,14 +116,14 @@ swagger_parser:
   # Set 'false' to use operationId
   path_method_name: false
 
-  # Optional (dart only). Set 'true' to include toJson() in enums. 
+  # Optional (dart only). Set 'true' to include toJson() in enums.
   # If set to false, serialization will use .name instead.
   enums_to_json: false
 
   # Optional. Set 'true' to set enum prefix from parent component.
   enums_parent_prefix: true
 
-  # Optional (dart only). Set 'true' to maintain backwards compatibility 
+  # Optional (dart only). Set 'true' to maintain backwards compatibility
   # when adding new values on the backend.
   unknown_enum_value: true
 
@@ -140,7 +142,7 @@ swagger_parser:
 
   # Optional. Skip parameters with names.
   skipped_parameters:
-    - 'X-Some-Token'
+    - "X-Some-Token"
 
   # Optional (dart & freezed only). Set 'true' to use Freezed 3.x code generation syntax.
   # Set 'false' to maintain compatibility with Freezed 2.x.
@@ -156,6 +158,21 @@ swagger_parser:
   # DART ONLY
   # Optional. Set `true` to use MultipartFile instead of File as argument type for file parameters.
   use_multipart_file: false
+
+  # DART ONLY
+  # Optional. Set tags to be excluded on endpoint generation.
+  #
+  # Endpoints with these tags will not be included in the generated clients.
+  exclude_tags:
+    - "sellPet"
+
+  # DART ONLY
+  # Optional. Set tags to be included on endpoint generation.
+  #
+  # If set, only endpoints with these tags will be included in the generated clients.
+  # **NOTE: This will override the [exclude_tags] if set.**
+  include_tags:
+    - "buyPet"
 ```
 
 For multiple schemes:
@@ -166,7 +183,7 @@ swagger_parser:
   output_directory: lib/api
   merge_clients: true
 
-  # Optional. You can pass a list of schemes. 
+  # Optional. You can pass a list of schemes.
   # Each schema inherits the parameters described in swagger_parser,
   # any parameter for any schema can be set manually.
   # Cannot be used at the same time as schema_path.
@@ -196,13 +213,15 @@ swagger_parser:
       language: kotlin
 ```
 
-
 ### Run the generator
+
 To generate code, run the `swagger_parser` program inside directory where your `pubspec.yaml` file is located:
+
 ```shell
 dart run swagger_parser
 ```
-If you name your configuration file something other than `swagger_parser.yaml` or `pubspec.yaml` 
+
+If you name your configuration file something other than `swagger_parser.yaml` or `pubspec.yaml`
 you will need to specify the name of the YAML file as an argument.
 
 ```shell
@@ -210,7 +229,9 @@ dart run swagger_parser -f <path to your config file>
 ```
 
 ### (Only for freezed) Generate files using [build_runner](https://pub.dev/packages/build_runner) for retrofit, json_serializable and freezed
+
 #### For `freezed` with `retrofit` use build.yaml file with this content:
+
 ```yaml
 global_options:
   freezed:
@@ -220,7 +241,9 @@ global_options:
     runs_before:
       - retrofit_generator
 ```
+
 To run the code generation with build_runner, execute the following command:
+
 ```shell
 dart run build_runner build -d
 ```

--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -38,6 +38,8 @@ class SWPConfig {
     this.useFreezed3 = false,
     this.useMultipartFile = false,
     this.fallbackUnion,
+    this.excludeTags = const <String>[],
+    this.includeTags = const <String>[],
   });
 
   /// Internal constructor of [SWPConfig]
@@ -69,6 +71,8 @@ class SWPConfig {
     required this.useXNullable,
     required this.useFreezed3,
     required this.useMultipartFile,
+    required this.excludeTags,
+    required this.includeTags,
     this.fallbackUnion,
   });
 
@@ -224,6 +228,41 @@ class SWPConfig {
     final fallbackUnion =
         yamlMap['fallback_union'] as String? ?? rootConfig?.fallbackUnion;
 
+    final excludedTagsYaml = yamlMap['exclude_tags'] as YamlList?;
+    List<String>? excludedTags;
+    if (excludedTagsYaml != null) {
+      excludedTags = [];
+      for (final t in excludedTagsYaml) {
+        if (t is! String) {
+          throw const ConfigException(
+            "Config parameter 'exclude_tags' values must be List of String.",
+          );
+        }
+        excludedTags.add(t);
+      }
+    } else if (rootConfig?.excludeTags != null) {
+      excludedTags = List.from(rootConfig!.excludeTags);
+    }
+
+    final includedTagsYaml = yamlMap['include_tags'] as YamlList?;
+    List<String>? includedTags;
+    if (includedTagsYaml != null) {
+      includedTags = [];
+      for (final t in includedTagsYaml) {
+        if (t is! String) {
+          throw const ConfigException(
+            "Config parameter 'include_tags' values must be List of String.",
+          );
+        }
+        includedTags.add(t);
+      }
+    } else if (rootConfig?.includeTags != null) {
+      includedTags = List.from(rootConfig!.includeTags);
+    }
+
+    print('excludedTags: $excludedTags');
+    print('includedTags: $includedTags');
+
     // Default config
     final dc = SWPConfig(name: name, outputDirectory: outputDirectory);
 
@@ -258,6 +297,8 @@ class SWPConfig {
       useFreezed3: useFreezed3 ?? dc.useFreezed3,
       useMultipartFile: useMultipartFile ?? dc.useMultipartFile,
       fallbackUnion: fallbackUnion,
+      excludeTags: excludedTags ?? dc.excludeTags,
+      includeTags: includedTags ?? dc.includeTags,
     );
   }
 
@@ -380,6 +421,19 @@ class SWPConfig {
   /// Optional. Set fallback consctructor name to use fallbackUnion parameter when using Freezed annotation.
   final String? fallbackUnion;
 
+  /// DART ONLY
+  /// Optional. Set excluded tags.
+  ///
+  /// Endpoints with these tags will not be included in the generated clients.
+  final List<String> excludeTags;
+
+  /// DART ONLY
+  /// Optional. Set included tags.
+  ///
+  /// If set, only endpoints with these tags will be included in the generated clients.
+  /// **NOTE: This will override the [excludeTags] if set.**
+  final List<String> includeTags;
+
   /// Convert [SWPConfig] to [GeneratorConfig]
   GeneratorConfig toGeneratorConfig() {
     return GeneratorConfig(
@@ -423,6 +477,8 @@ class SWPConfig {
       skippedParameters: skippedParameters,
       replacementRules: replacementRules,
       useXNullable: useXNullable,
+      excludeTags: excludeTags,
+      includeTags: includeTags,
     );
   }
 }

--- a/swagger_parser/lib/src/parser/config/parser_config.dart
+++ b/swagger_parser/lib/src/parser/config/parser_config.dart
@@ -14,6 +14,8 @@ class ParserConfig {
     this.skippedParameters = const <String>[],
     this.replacementRules = const [],
     this.useXNullable = false,
+    this.excludeTags = const <String>[],
+    this.includeTags = const <String>[],
   });
 
   /// Specification file content as [String]
@@ -54,4 +56,15 @@ class ParserConfig {
   /// Does the Schema use x-nullable to indicate nullable fields
   /// Only used for OpenApi v2
   final bool useXNullable;
+
+  /// Optional. Set excluded tags.
+  ///
+  /// Endpoints with these tags will not be included in the generated clients.
+  final List<String> excludeTags;
+
+  /// Optional. Set included tags.
+  ///
+  /// If set, only endpoints with these tags will be included in the generated clients.
+  /// **NOTE: This will override the [excludeTags] if set.**
+  final List<String> includeTags;
 }

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -569,6 +569,12 @@ class OpenApiParser {
       }
 
       pathValue.forEach((key, requestPath) {
+        // check if this requestPath has any tags that
+        // define wether the requestPath should be included
+        if (!_includeTag(requestPath as Map<String, dynamic>)) {
+          return;
+        }
+
         // `servers` contains List<dynamic>
         if (key == _serversConst ||
             key == _parametersConst ||
@@ -576,8 +582,8 @@ class OpenApiParser {
           return;
         }
 
-        final requestPathResponses = (requestPath
-            as Map<String, dynamic>)[_responsesConst] as Map<String, dynamic>;
+        final requestPathResponses =
+            requestPath[_responsesConst] as Map<String, dynamic>;
         final additionalName = '$key${path}Response'.toPascal;
         final returnType = _apiInfo.schemaVersion == OAS.v2
             ? returnTypeV2(requestPathResponses, additionalName)
@@ -975,6 +981,33 @@ class OpenApiParser {
     }
 
     return dataClasses;
+  }
+
+  /// Check if any tag of a given endpoint is included or excluded
+  ///
+  /// It will return true if the [ParserConfig.includeTags] is not empty
+  /// and the any tag of this endpoint is included, afterwards
+  /// it will check if the [ParserConfig.excludeTags] is not empty
+  /// and the any tag of this endpoint is excluded.
+  ///
+  /// If the tag is neither included nor excluded or if there is no tag at all,
+  /// it will return true.
+  bool _includeTag(Map<String, dynamic> map) {
+    if (!map.containsKey(_tagsConst)) {
+      return true;
+    }
+
+    final tags = (map[_tagsConst] as List<dynamic>).map((e) => e as String);
+
+    if (config.includeTags.isNotEmpty) {
+      return config.includeTags.any(tags.contains);
+    }
+
+    if (config.excludeTags.isNotEmpty) {
+      return !config.excludeTags.any(tags.contains);
+    }
+
+    return true;
   }
 
   /// Get tag for name

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -421,6 +421,49 @@ void main() {
       );
     });
 
+    test('excluded_tags', () async {
+      await e2eTest(
+        'basic/excluded_tags',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          excludeTags: ['exclude'],
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('included_tags', () async {
+      await e2eTest(
+        'basic/included_tags',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          includeTags: ['include'],
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('included_and_excluded_tags', () async {
+      await e2eTest(
+        'basic/included_and_excluded_tags',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          includeTags: ['include'],
+          excludeTags: ['exclude'],
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
     test('use_freezed3.3.0', () async {
       await e2eTest(
         'basic/use_freezed3.3.0',

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/clients/client_client.dart
@@ -1,0 +1,16 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/api/v1/not-tagged-should-be-included/')
+  Future<void> apiV1CategoryList();
+}

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/export.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+///  `v0.0.0 (v1)`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '0.0.0 (v1)';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags/openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.1.0
+info:
+  title: ""
+  version: 0.0.0 (v1)
+paths:
+  /api/v1/tagged-as-client-should-be-excluded/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+        - exclude
+      responses:
+        "204":
+          description: ""
+  /api/v1/not-tagged-should-be-included/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+      responses:
+        "204":
+          description: ""

--- a/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/clients/client_client.dart
@@ -1,0 +1,16 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/api/v1/tagged-as-exclude-but-included-should-be-included/')
+  Future<void> apiV1CategoryList();
+}

--- a/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/export.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+///  `v0.0.0 (v1)`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '0.0.0 (v1)';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/openapi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: ""
+  version: 0.0.0 (v1)
+paths:
+  /api/v1/tagged-as-exclude-but-included-should-be-included/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+        - include
+        - exclude
+      responses:
+        "204":
+          description: ""
+  /api/v1/tagged-as-exclude-but-not-included-should-be-excluded/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+        - exclude
+      responses:
+        "204":
+          description: ""

--- a/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/clients/client_client.dart
@@ -1,0 +1,16 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/api/v1/tagged-as-include-should-be-included/')
+  Future<void> apiV1CategoryList();
+}

--- a/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/export.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+///  `v0.0.0 (v1)`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '0.0.0 (v1)';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/included_tags/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/included_tags/openapi.yaml
@@ -1,0 +1,22 @@
+openapi: 3.1.0
+info:
+  title: ""
+  version: 0.0.0 (v1)
+paths:
+  /api/v1/tagged-as-include-should-be-included/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+        - include
+      responses:
+        "204":
+          description: ""
+  /api/v1/not-tagged-should-be-excluded/:
+    get:
+      operationId: api_v1_category_list
+      tags:
+        - client
+      responses:
+        "204":
+          description: ""


### PR DESCRIPTION
This PR adresses https://github.com/Carapacik/swagger_parser/issues/344 . It allows to filter the generation of endpoints in clients by their tags. Either by including tags via include_tags or by excluding tags via exclude_tags.

The logic will first check if any tag is listed include_tags. API-Methods will only be generated for tags from this list. Any tags listed in exclude_tags will be ignored if the same endpoint is included via include_tags. Endpoints with tags that are not listed in include_tags will be ignored.

If include_tags is empty, the exclude_tags filter will be applied by not generating API-Methods for all endpoints that have a tag which is listed in exclude_tags.

The README has been updated and tests added.