### PR TITLE
fix: ensure consistent file naming for tags with alphanumeric suffixes

### DIFF
--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -66,11 +66,10 @@ final class FillController {
     final rootClientName = config.rootClientName ?? 'RestClient';
     final postfix = config.clientPostfix ?? 'Client';
     final clientsNames = clients.map((c) => c.name.toPascal).toSet();
-    // Create a map from Pascal names to original snake names
-    final clientsNameMap = <String, String>{};
-    for (final client in clients) {
-      clientsNameMap[client.name.toPascal] = client.name;
-    }
+    // Create a map from Pascal names to snake names
+    final clientsNameMap = <String, String>{
+      for (final client in clients) client.name.toPascal: client.name.toSnake
+    };
 
     return GeneratedFile(
       name: '${rootClientName.toSnake}.${config.language.fileExtension}',

--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -56,6 +56,7 @@ final class FillController {
         dioOptionsParameterByDefault: config.dioOptionsParameterByDefault,
         originalHttpResponse: config.originalHttpResponse,
         useMultipartFile: config.useMultipartFile,
+        fileName: fileName,
       ),
     );
   }
@@ -65,6 +66,11 @@ final class FillController {
     final rootClientName = config.rootClientName ?? 'RestClient';
     final postfix = config.clientPostfix ?? 'Client';
     final clientsNames = clients.map((c) => c.name.toPascal).toSet();
+    // Create a map from Pascal names to original snake names
+    final clientsNameMap = <String, String>{};
+    for (final client in clients) {
+      clientsNameMap[client.name.toPascal] = client.name;
+    }
 
     return GeneratedFile(
       name: '${rootClientName.toSnake}.${config.language.fileExtension}',
@@ -75,6 +81,7 @@ final class FillController {
         postfix: postfix.toPascal,
         putClientsInFolder: config.putClientsInFolder,
         markFilesAsGenerated: config.markFilesAsGenerated,
+        clientsNameMap: clientsNameMap,
       ),
     );
   }

--- a/swagger_parser/lib/src/generator/model/programming_language.dart
+++ b/swagger_parser/lib/src/generator/model/programming_language.dart
@@ -122,6 +122,7 @@ enum ProgrammingLanguage {
     bool extrasParameterByDefault = false,
     bool dioOptionsParameterByDefault = false,
     bool originalHttpResponse = false,
+    String? fileName,
   }) =>
       switch (this) {
         dart => dartRetrofitClientTemplate(
@@ -133,6 +134,7 @@ enum ProgrammingLanguage {
             dioOptionsParameterByDefault: dioOptionsParameterByDefault,
             originalHttpResponse: originalHttpResponse,
             useMultipartFile: useMultipartFile,
+            fileName: fileName,
           ),
         kotlin => kotlinRetrofitClientTemplate(
             restClient: restClient,
@@ -149,6 +151,7 @@ enum ProgrammingLanguage {
     required String postfix,
     required bool putClientsInFolder,
     required bool markFilesAsGenerated,
+    Map<String, String>? clientsNameMap,
   }) =>
       switch (this) {
         dart => dartRootClientTemplate(
@@ -158,6 +161,7 @@ enum ProgrammingLanguage {
             postfix: postfix,
             putClientsInFolder: putClientsInFolder,
             markFileAsGenerated: markFilesAsGenerated,
+            clientsNameMap: clientsNameMap,
           ),
         kotlin => '',
       };

--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -16,6 +16,7 @@ String dartRetrofitClientTemplate({
   bool extrasParameterByDefault = false,
   bool dioOptionsParameterByDefault = false,
   bool originalHttpResponse = false,
+  String? fileName,
 }) {
   final parameterTypes = restClient.requests
       .expand((r) => r.parameters.map((p) => p.type))
@@ -24,7 +25,7 @@ String dartRetrofitClientTemplate({
 ${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}${_convertImport(restClient)}${ioImport(parameterTypes, useMultipartFile: useMultipartFile)}import 'package:dio/dio.dart'${_hideHeaders(restClient, defaultContentType)};
 import 'package:retrofit/retrofit.dart';
 ${dartImports(imports: restClient.imports, pathPrefix: '../models/')}
-part '${name.toSnake}.g.dart';
+part '${fileName ?? name.toSnake}.g.dart';
 
 @RestApi()
 abstract class $name {

--- a/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
@@ -9,6 +9,7 @@ String dartRootClientTemplate({
   required String postfix,
   required bool putClientsInFolder,
   required bool markFileAsGenerated,
+  Map<String, String>? clientsNameMap,
 }) {
   if (clientsNames.isEmpty) {
     return '';
@@ -32,7 +33,7 @@ String dartRootClientTemplate({
 
   return '''
 ${generatedFileComment(markFileAsGenerated: markFileAsGenerated)}import 'package:dio/dio.dart';
-${_clientsImport(clientsNames, postfix, putClientsInFolder: putClientsInFolder)}
+${_clientsImport(clientsNames, postfix, putClientsInFolder: putClientsInFolder, clientsNameMap: clientsNameMap)}
 ${descriptionComment(comment)}class $className {
   $className(
     Dio dio, {
@@ -53,9 +54,13 @@ ${_getters(clientsNames, postfix)}
 }
 
 String _clientsImport(Set<String> imports, String postfix,
-        {required bool putClientsInFolder}) =>
-    '\n${imports.map((import) => "import '${putClientsInFolder ? 'clients' : import.toSnake}/"
-        "${'${import}_$postfix'.toSnake}.dart';").join('\n')}\n';
+        {required bool putClientsInFolder, Map<String, String>? clientsNameMap}) {
+  return '\n${imports.map((import) {
+    final snakeName = clientsNameMap?[import] ?? import.toSnake;
+    return "import '${putClientsInFolder ? 'clients' : snakeName}/"
+        "${snakeName}_${postfix.toLowerCase()}.dart';";
+  }).join('\n')}\n';
+}
 
 String _privateFields(Set<String> names, String postfix) => names
     .map((n) => '  ${n.toPascal + postfix.toPascal}? _${n.toCamel};')

--- a/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
@@ -58,7 +58,7 @@ String _clientsImport(Set<String> imports, String postfix,
   return '\n${imports.map((import) {
     final snakeName = clientsNameMap?[import] ?? import.toSnake;
     return "import '${putClientsInFolder ? 'clients' : snakeName}/"
-        "${snakeName}_${postfix.toLowerCase()}.dart';";
+        "${snakeName}_${postfix.toSnake}.dart';";
   }).join('\n')}\n';
 }
 

--- a/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_root_client_template.dart
@@ -54,7 +54,7 @@ ${_getters(clientsNames, postfix)}
 }
 
 String _clientsImport(Set<String> imports, String postfix,
-        {required bool putClientsInFolder, Map<String, String>? clientsNameMap}) {
+    {required bool putClientsInFolder, Map<String, String>? clientsNameMap}) {
   return '\n${imports.map((import) {
     final snakeName = clientsNameMap?[import] ?? import.toSnake;
     return "import '${putClientsInFolder ? 'clients' : snakeName}/"

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -533,5 +533,32 @@ void main() {
         schemaFileName: 'wrapping_collections.3.0.json',
       );
     });
+
+    // https://github.com/Carapacik/swagger_parser/issues/353
+    test('tag_with_alphanumeric', () async {
+      await e2eTest(
+        'tag_with_alphanumeric',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.json',
+      );
+    });
+
+    test('tag_edge_cases', () async {
+      await e2eTest(
+        'tag_edge_cases',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
   });
 }

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/items_2a3_version_4b5_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/items_2a3_version_4b5_client.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/item.dart';
+
+part 'items_2a3_version_4b5_client.g.dart';
+
+@RestApi()
+abstract class Items2a3Version4b5Client {
+  factory Items2a3Version4b5Client(Dio dio, {String? baseUrl}) =
+      _Items2a3Version4b5Client;
+
+  /// Get items with multiple version markers
+  @GET('/items/multi-version')
+  Future<List<Item>> getMultiVersionItems();
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/items_draft_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/items_draft_client.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/draft_item.dart';
+
+part 'items_draft_client.g.dart';
+
+@RestApi()
+abstract class ItemsDraftClient {
+  factory ItemsDraftClient(Dio dio, {String? baseUrl}) = _ItemsDraftClient;
+
+  /// Get draft items
+  @GET('/items/draft')
+  Future<List<DraftItem>> getDraftItems();
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/very_long_tag_name_with_numbers_123_and_more_text_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/clients/very_long_tag_name_with_numbers_123_and_more_text_client.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/long_tag_response.dart';
+
+part 'very_long_tag_name_with_numbers_123_and_more_text_client.g.dart';
+
+@RestApi()
+abstract class VeryLongTagNameWithNumbers123AndMoreTextClient {
+  factory VeryLongTagNameWithNumbers123AndMoreTextClient(Dio dio,
+      {String? baseUrl}) = _VeryLongTagNameWithNumbers123AndMoreTextClient;
+
+  /// Operation with very long tag
+  @GET('/very/long/path')
+  Future<LongTagResponse> getLongTagData();
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/export.dart
@@ -1,0 +1,14 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/items_2a3_version_4b5_client.dart';
+export 'clients/items_draft_client.dart';
+export 'clients/very_long_tag_name_with_numbers_123_and_more_text_client.dart';
+// Data classes
+export 'models/item.dart';
+export 'models/draft_item.dart';
+export 'models/long_tag_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/draft_item.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/draft_item.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'draft_item.freezed.dart';
+part 'draft_item.g.dart';
+
+@Freezed()
+class DraftItem with _$DraftItem {
+  const factory DraftItem({
+    String? id,
+    String? content,
+    bool? isDraft,
+  }) = _DraftItem;
+
+  factory DraftItem.fromJson(Map<String, Object?> json) =>
+      _$DraftItemFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/item.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/item.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item.freezed.dart';
+part 'item.g.dart';
+
+@Freezed()
+class Item with _$Item {
+  const factory Item({
+    String? id,
+    String? name,
+    String? version,
+  }) = _Item;
+
+  factory Item.fromJson(Map<String, Object?> json) => _$ItemFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/long_tag_response.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/models/long_tag_response.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'long_tag_response.freezed.dart';
+part 'long_tag_response.g.dart';
+
+@Freezed()
+class LongTagResponse with _$LongTagResponse {
+  const factory LongTagResponse({
+    String? data,
+    DateTime? timestamp,
+  }) = _LongTagResponse;
+
+  factory LongTagResponse.fromJson(Map<String, Object?> json) =>
+      _$LongTagResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/expected_files/rest_client.dart
@@ -1,0 +1,42 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/items_2a3_version_4b5_client.dart';
+import 'clients/items_draft_client.dart';
+import 'clients/very_long_tag_name_with_numbers_123_and_more_text_client.dart';
+
+/// Tag Edge Cases Test API `v1.0.0`.
+///
+/// Test API to verify various tag naming edge cases.
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  Items2a3Version4b5Client? _items2a3Version4b5;
+  ItemsDraftClient? _itemsDraft;
+  VeryLongTagNameWithNumbers123AndMoreTextClient?
+      _veryLongTagNameWithNumbers123AndMoreText;
+
+  Items2a3Version4b5Client get items2a3Version4b5 =>
+      _items2a3Version4b5 ??= Items2a3Version4b5Client(_dio, baseUrl: _baseUrl);
+
+  ItemsDraftClient get itemsDraft =>
+      _itemsDraft ??= ItemsDraftClient(_dio, baseUrl: _baseUrl);
+
+  VeryLongTagNameWithNumbers123AndMoreTextClient
+      get veryLongTagNameWithNumbers123AndMoreText =>
+          _veryLongTagNameWithNumbers123AndMoreText ??=
+              VeryLongTagNameWithNumbers123AndMoreTextClient(_dio,
+                  baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/tag_edge_cases/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/tag_edge_cases/openapi.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.3
+info:
+  title: Tag Edge Cases Test API
+  description: Test API to verify various tag naming edge cases
+  version: 1.0.0
+
+servers:
+  - url: https://api.example.com
+
+tags:
+  - name: Items - 2a3 - Version 4b5
+    description: Multiple alphanumeric sequences in one tag
+  - name: Items -- Draft
+    description: Multiple consecutive hyphens
+  - name: Very Long Tag Name With Numbers 123 And More Text
+    description: Very long tags with numbers
+
+paths:
+  /items/multi-version:
+    get:
+      tags:
+        - Items - 2a3 - Version 4b5
+      summary: Get items with multiple version markers
+      operationId: getMultiVersionItems
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+
+
+  /items/draft:
+    get:
+      tags:
+        - Items -- Draft
+      summary: Get draft items
+      operationId: getDraftItems
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DraftItem'
+
+  /very/long/path:
+    get:
+      tags:
+        - Very Long Tag Name With Numbers 123 And More Text
+      summary: Operation with very long tag
+      operationId: getLongTagData
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LongTagResponse'
+
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+
+
+    DraftItem:
+      type: object
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+        isDraft:
+          type: boolean
+
+    LongTagResponse:
+      type: object
+      properties:
+        data:
+          type: string
+        timestamp:
+          type: string
+          format: date-time

--- a/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/clients/items_2a3_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/clients/items_2a3_client.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/item.dart';
+
+part 'items_2a3_client.g.dart';
+
+@RestApi()
+abstract class Items2a3Client {
+  factory Items2a3Client(Dio dio, {String? baseUrl}) = _Items2a3Client;
+
+  /// Get all items
+  @GET('/items/list')
+  Future<List<Item>> getItems();
+}

--- a/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/items_2a3_client.dart';
+// Data classes
+export 'models/item.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/models/item.dart
+++ b/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/models/item.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item.freezed.dart';
+part 'item.g.dart';
+
+@Freezed()
+class Item with _$Item {
+  const factory Item({
+    String? id,
+    String? name,
+    String? type,
+  }) = _Item;
+
+  factory Item.fromJson(Map<String, Object?> json) => _$ItemFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_with_alphanumeric/expected_files/rest_client.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/items_2a3_client.dart';
+
+/// Test API `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  Items2a3Client? _items2a3;
+
+  Items2a3Client get items2a3 =>
+      _items2a3 ??= Items2a3Client(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/tag_with_alphanumeric/openapi.json
+++ b/swagger_parser/test/e2e/tests/tag_with_alphanumeric/openapi.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/items/list": {
+      "get": {
+        "tags": ["Items - 2a3"],
+        "summary": "Get all items",
+        "operationId": "getItems",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Item"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Item": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR fixes the issue where OpenAPI tags with alphanumeric suffixes (e.g., "Items - 2a3") were causing inconsistent file naming between generated files.

## Problem
When tags contain alphanumeric sequences, the code generator was creating inconsistent file naming:
- File names used underscores: `items_2a3_client.dart`  
- Import statements lost underscores: `import 'clients/items2a3_client.dart';`
- Part directives also lost underscores: `part 'items2a3_client.g.dart';`

This caused compilation errors due to mismatched file paths.

## Root Cause
The issue occurred when snake_case tag names were converted to PascalCase and then back to snake_case for file paths. The case conversion logic lost the underscore information when handling alphanumeric sequences.

## Solution
- Pass original snake_case names alongside PascalCase names to templates
- Use the original snake_case names for file paths and imports
- Preserve PascalCase names for class names
- Fix postfix casing in import statements (Client -> client)

## Changes
- Modified `fill_controller.dart` to create and pass name mappings
- Updated `programming_language.dart` to accept additional parameters
- Fixed `dart_root_client_template.dart` to use original names for imports
- Fixed `dart_retrofit_client_template.dart` to use original names for part directives
- Added comprehensive e2e tests for various tag edge cases

## Test Coverage
Added two new e2e tests:
1. `tag_with_alphanumeric` - Tests single alphanumeric sequence
2. `tag_edge_cases` - Tests multiple edge cases including:
   - Multiple alphanumeric sequences in one tag
   - Long tag names with numbers
   - Mixed alphanumeric patterns

All tests are passing ✅

Fixes #353

🤖 Generated with [Claude Code](https://claude.ai/code)