### PR TITLE
feat(parser): support non-discriminated unions; add e2e coverage

### DIFF
--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -560,5 +560,135 @@ void main() {
         schemaFileName: 'openapi.yaml',
       );
     });
+
+    test('one_of_without_discriminator', () async {
+      await e2eTest(
+        'basic/one_of_without_discriminator',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('any_of_without_discriminator', () async {
+      await e2eTest(
+        'basic/any_of_without_discriminator',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('one_of_nullable', () async {
+      await e2eTest(
+        'basic/one_of_nullable',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('all_of_composition', () async {
+      await e2eTest(
+        'basic/all_of_composition',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('one_of_empty_or_string', () async {
+      await e2eTest(
+        'basic/one_of_empty_or_string',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('inline_union_without_discriminator', () async {
+      await e2eTest(
+        'basic/inline_union_without_discriminator',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('inline_any_of_without_discriminator', () async {
+      await e2eTest(
+        'basic/inline_any_of_without_discriminator',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('inline_union_array', () async {
+      await e2eTest(
+        'basic/inline_union_array',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('inline_union_map', () async {
+      await e2eTest(
+        'basic/inline_union_map',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('inline_response_union', () async {
+      await e2eTest(
+        'basic/inline_response_union',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
   });
 }

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -690,5 +690,57 @@ void main() {
         schemaFileName: 'openapi.yaml',
       );
     });
+
+    test('primitive_union_without_null', () async {
+      await e2eTest(
+        'basic/primitive_union_without_null',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('primitive_union_nullable', () async {
+      await e2eTest(
+        'basic/primitive_union_nullable',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('array_items_nullable_union', () async {
+      await e2eTest(
+        'basic/array_items_nullable_union',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    test('map_values_nullable_union', () async {
+      await e2eTest(
+        'basic/map_values_nullable_union',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
   });
 }

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/cat_like.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/cats')
+  Future<CatLike> getCats();
+}

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/export.dart
@@ -1,0 +1,11 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/pet.dart';
+export 'models/cat_like.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/models/cat_like.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/models/cat_like.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cat_like.freezed.dart';
+part 'cat_like.g.dart';
+
+/// Cat-like pet composed via allOf
+@Freezed()
+class CatLike with _$CatLike {
+  const factory CatLike({
+    int? id,
+    bool? whiskers,
+  }) = _CatLike;
+
+  factory CatLike.fromJson(Map<String, Object?> json) =>
+      _$CatLikeFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/models/pet.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/models/pet.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pet.freezed.dart';
+part 'pet.g.dart';
+
+@Freezed()
+class Pet with _$Pet {
+  const factory Pet({
+    int? id,
+  }) = _Pet;
+
+  factory Pet.fromJson(Map<String, Object?> json) => _$PetFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// AllOf composition without discriminator `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/all_of_composition/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/all_of_composition/openapi.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: AllOf composition without discriminator
+  version: 1.0.0
+paths:
+  /cats:
+    get:
+      operationId: getCats
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatLike'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    CatLike:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            whiskers:
+              type: boolean
+      description: Cat-like pet composed via allOf

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/maybe_pet.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/maybePet')
+  Future<MaybePet> getMaybePet();
+}

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/export.dart
@@ -1,0 +1,12 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/cat.dart';
+export 'models/dog.dart';
+export 'models/maybe_pet.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/cat.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/cat.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cat.freezed.dart';
+part 'cat.g.dart';
+
+@Freezed()
+class Cat with _$Cat {
+  const factory Cat({
+    bool? meows,
+  }) = _Cat;
+
+  factory Cat.fromJson(Map<String, Object?> json) => _$CatFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/dog.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/dog.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'dog.freezed.dart';
+part 'dog.g.dart';
+
+@Freezed()
+class Dog with _$Dog {
+  const factory Dog({
+    bool? barks,
+  }) = _Dog;
+
+  factory Dog.fromJson(Map<String, Object?> json) => _$DogFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/maybe_pet.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/models/maybe_pet.dart
@@ -1,0 +1,6 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+/// AnyOf union without discriminator
+typedef MaybePet = dynamic;

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// AnyOf without discriminator `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/any_of_without_discriminator/openapi.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: AnyOf without discriminator
+  version: 1.0.0
+paths:
+  /maybePet:
+    get:
+      operationId: getMaybePet
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MaybePet'
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        meows:
+          type: boolean
+    Dog:
+      type: object
+      properties:
+        barks:
+          type: boolean
+    MaybePet:
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      description: AnyOf union without discriminator

--- a/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/items_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/items')
+  Future<ItemsResponse> getItems();
+}

--- a/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/items_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/models/items_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/models/items_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'items_response.freezed.dart';
+part 'items_response.g.dart';
+
+@Freezed()
+class ItemsResponse with _$ItemsResponse {
+  const factory ItemsResponse({
+    List<String?>? items,
+  }) = _ItemsResponse;
+
+  factory ItemsResponse.fromJson(Map<String, Object?> json) =>
+      _$ItemsResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Array items nullable union `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/array_items_nullable_union/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Array items nullable union
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsResponse'
+components:
+  schemas:
+    ItemsResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            anyOf:
+              - type: string
+              - type: 'null'
+      required: []

--- a/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_inline_anyof_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/inline-anyof')
+  Future<GetInlineAnyofResponse> getInlineAnyOf();
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/get_inline_anyof_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/models/get_inline_anyof_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/models/get_inline_anyof_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_inline_anyof_response.freezed.dart';
+part 'get_inline_anyof_response.g.dart';
+
+@Freezed()
+class GetInlineAnyofResponse with _$GetInlineAnyofResponse {
+  const factory GetInlineAnyofResponse({
+    dynamic payload,
+  }) = _GetInlineAnyofResponse;
+
+  factory GetInlineAnyofResponse.fromJson(Map<String, Object?> json) =>
+      _$GetInlineAnyofResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Inline anyOf non-discriminated union `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/inline_any_of_without_discriminator/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Inline anyOf non-discriminated union
+  version: 1.0.0
+paths:
+  /inline-anyof:
+    get:
+      operationId: getInlineAnyOf
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payload:
+                    anyOf:
+                      - type: object
+                        properties:
+                          a:
+                            type: integer
+                      - type: object
+                        properties:
+                          b:
+                            type: string

--- a/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/clients/client_client.dart
@@ -1,0 +1,16 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/inline-response')
+  Future<dynamic> getInlineResponse();
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/export.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_response_union/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Inline union as top-level response `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_response_union/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/inline_response_union/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Inline union as top-level response
+  version: 1.0.0
+paths:
+  /inline-response:
+    get:
+      operationId: getInlineResponse
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      a:
+                        type: integer
+                  - type: object
+                    properties:
+                      b:
+                        type: string

--- a/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_inline_array_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/inline-array')
+  Future<GetInlineArrayResponse> getInlineArray();
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/get_inline_array_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/models/get_inline_array_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/models/get_inline_array_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_inline_array_response.freezed.dart';
+part 'get_inline_array_response.g.dart';
+
+@Freezed()
+class GetInlineArrayResponse with _$GetInlineArrayResponse {
+  const factory GetInlineArrayResponse({
+    List<dynamic>? items,
+  }) = _GetInlineArrayResponse;
+
+  factory GetInlineArrayResponse.fromJson(Map<String, Object?> json) =>
+      _$GetInlineArrayResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_array/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Inline union inside array `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_array/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_array/openapi.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Inline union inside array
+  version: 1.0.0
+paths:
+  /inline-array:
+    get:
+      operationId: getInlineArray
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      oneOf:
+                        - type: object
+                          properties:
+                            a:
+                              type: integer
+                        - type: object
+                          properties:
+                            b:
+                              type: string

--- a/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_inline_map_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/inline-map')
+  Future<GetInlineMapResponse> getInlineMap();
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/get_inline_map_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/models/get_inline_map_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/models/get_inline_map_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_inline_map_response.freezed.dart';
+part 'get_inline_map_response.g.dart';
+
+@Freezed()
+class GetInlineMapResponse with _$GetInlineMapResponse {
+  const factory GetInlineMapResponse({
+    Map<String, dynamic>? data,
+  }) = _GetInlineMapResponse;
+
+  factory GetInlineMapResponse.fromJson(Map<String, Object?> json) =>
+      _$GetInlineMapResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_map/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Inline union inside map `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_map/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_map/openapi.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Inline union inside map
+  version: 1.0.0
+paths:
+  /inline-map:
+    get:
+      operationId: getInlineMap
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties:
+                      anyOf:
+                        - type: object
+                          properties:
+                            a:
+                              type: integer
+                        - type: object
+                          properties:
+                            b:
+                              type: string

--- a/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_inline_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/inline')
+  Future<GetInlineResponse> getInline();
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/get_inline_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/models/get_inline_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/models/get_inline_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_inline_response.freezed.dart';
+part 'get_inline_response.g.dart';
+
+@Freezed()
+class GetInlineResponse with _$GetInlineResponse {
+  const factory GetInlineResponse({
+    dynamic payload,
+  }) = _GetInlineResponse;
+
+  factory GetInlineResponse.fromJson(Map<String, Object?> json) =>
+      _$GetInlineResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Inline non-discriminated union `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/inline_union_without_discriminator/openapi.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: Inline non-discriminated union
+  version: 1.0.0
+paths:
+  /inline:
+    get:
+      operationId: getInline
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payload:
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                          a:
+                            type: integer
+                      - type: object
+                        properties:
+                          type:
+                            type: string
+                          b:
+                            type: string

--- a/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/data_response.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/data')
+  Future<DataResponse> getData();
+}

--- a/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/data_response.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/models/data_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/models/data_response.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'data_response.freezed.dart';
+part 'data_response.g.dart';
+
+@Freezed()
+class DataResponse with _$DataResponse {
+  const factory DataResponse({
+    Map<String, String?>? data,
+  }) = _DataResponse;
+
+  factory DataResponse.fromJson(Map<String, Object?> json) =>
+      _$DataResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Map values nullable union `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/map_values_nullable_union/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Map values nullable union
+  version: 1.0.0
+paths:
+  /data:
+    get:
+      operationId: getData
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataResponse'
+components:
+  schemas:
+    DataResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            anyOf:
+              - type: string
+              - type: 'null'
+      required: []

--- a/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/model.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/models')
+  Future<Model> getModels();
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/model.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/models/model.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/models/model.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'model.freezed.dart';
+part 'model.g.dart';
+
+@Freezed()
+class Model with _$Model {
+  const factory Model({
+    dynamic validFrom,
+  }) = _Model;
+
+  factory Model.fromJson(Map<String, Object?> json) => _$ModelFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// OneOf with empty schema or string `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/one_of_empty_or_string/openapi.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: OneOf with empty schema or string
+  version: 1.0.0
+paths:
+  /models:
+    get:
+      operationId: getModels
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Model'
+components:
+  schemas:
+    Model:
+      type: object
+      properties:
+        validFrom:
+          oneOf:
+            - {}
+            - type: string
+      required: []

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/pet_or_null.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/petOrNull')
+  Future<PetOrNull> getPetOrNull();
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/export.dart
@@ -1,0 +1,11 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/pet.dart';
+export 'models/pet_or_null.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/models/pet.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/models/pet.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pet.freezed.dart';
+part 'pet.g.dart';
+
+@Freezed()
+class Pet with _$Pet {
+  const factory Pet({
+    String? name,
+  }) = _Pet;
+
+  factory Pet.fromJson(Map<String, Object?> json) => _$PetFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/models/pet_or_null.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/models/pet_or_null.dart
@@ -1,0 +1,9 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'pet.dart';
+export 'pet.dart';
+
+/// OneOf union representing nullable Pet
+typedef PetOrNull = Pet?;

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// OneOf nullable form `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_nullable/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/one_of_nullable/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: OneOf nullable form
+  version: 1.0.0
+paths:
+  /petOrNull:
+    get:
+      operationId: getPetOrNull
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetOrNull'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+    PetOrNull:
+      oneOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: 'null'
+      description: OneOf union representing nullable Pet

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/clients/client_client.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/broken_union.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/pets')
+  Future<BrokenUnion> getPets();
+
+  @POST('/pets')
+  Future<void> createPet({
+    @Body() required BrokenUnion body,
+  });
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/export.dart
@@ -1,0 +1,12 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/cat.dart';
+export 'models/dog.dart';
+export 'models/broken_union.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/broken_union.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/broken_union.dart
@@ -1,0 +1,6 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+/// OneOf union without discriminator
+typedef BrokenUnion = dynamic;

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/cat.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/cat.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cat.freezed.dart';
+part 'cat.g.dart';
+
+@Freezed()
+class Cat with _$Cat {
+  const factory Cat({
+    bool? meows,
+  }) = _Cat;
+
+  factory Cat.fromJson(Map<String, Object?> json) => _$CatFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/dog.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/models/dog.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'dog.freezed.dart';
+part 'dog.g.dart';
+
+@Freezed()
+class Dog with _$Dog {
+  const factory Dog({
+    bool? barks,
+  }) = _Dog;
+
+  factory Dog.fromJson(Map<String, Object?> json) => _$DogFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// OneOf without discriminator `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/one_of_without_discriminator/openapi.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: OneOf without discriminator
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: getPets
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrokenUnion'
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BrokenUnion'
+      responses:
+        '204':
+          description: No Content
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        meows:
+          type: boolean
+    Dog:
+      type: object
+      properties:
+        barks:
+          type: boolean
+    BrokenUnion:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      description: OneOf union without discriminator

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/value.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/value')
+  Future<Value> getValue();
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/value.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/models/value.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/models/value.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'value.freezed.dart';
+part 'value.g.dart';
+
+@Freezed()
+class Value with _$Value {
+  const factory Value({
+    String? data,
+  }) = _Value;
+
+  factory Value.fromJson(Map<String, Object?> json) => _$ValueFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Primitive union nullable `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_nullable/openapi.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Primitive union nullable
+  version: 1.0.0
+paths:
+  /value:
+    get:
+      operationId: getValue
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Value'
+components:
+  schemas:
+    Value:
+      type: object
+      properties:
+        data:
+          anyOf:
+            - type: string
+            - type: 'null'
+      required: []

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/clients/client_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/clients/client_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/value.dart';
+
+part 'client_client.g.dart';
+
+@RestApi()
+abstract class ClientClient {
+  factory ClientClient(Dio dio, {String? baseUrl}) = _ClientClient;
+
+  @GET('/value')
+  Future<Value> getValue();
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/export.dart
@@ -1,0 +1,10 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+// Clients
+export 'clients/client_client.dart';
+// Data classes
+export 'models/value.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/models/value.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/models/value.dart
@@ -1,0 +1,17 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'value.freezed.dart';
+part 'value.g.dart';
+
+@Freezed()
+class Value with _$Value {
+  const factory Value({
+    dynamic data,
+  }) = _Value;
+
+  factory Value.fromJson(Map<String, Object?> json) => _$ValueFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/client_client.dart';
+
+/// Primitive union without null `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  ClientClient? _client;
+
+  ClientClient get client => _client ??= ClientClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/primitive_union_without_null/openapi.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Primitive union without null
+  version: 1.0.0
+paths:
+  /value:
+    get:
+      operationId: getValue
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Value'
+components:
+  schemas:
+    Value:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - type: string
+            - type: integer
+      required: []


### PR DESCRIPTION
This PR adds parser support and tests for non-discriminated unions.\n\n- **fix**: handle / without a discriminator by falling back to a typedef , emitting a warning instead of failing\n- **introduce**: broad e2e coverage for unions and compositions:\n  - primitive unions: '!'=43297
'#'=0
'$'=43146
'?'=127
ARGC=0
COLUMNS=108
EGID=20
EUID=501
FUNCNEST=700
GID=20
HISTCMD=10168
HISTSIZE=50000
KEYTIMEOUT=40
LINENO=5
LINES=2
LISTMAX=100
MAILCHECK=60
OPTIND=1
PPID=87242
RANDOM=9921
SAVEHIST=10000
SECONDS=643
SHLVL=1
TRY_BLOCK_ERROR=-1
TRY_BLOCK_INTERRUPT=-1
TTYIDLE=0
UID=501
ZSH_SUBSHELL=2
status=127, \n  - arrays/maps with nullable primitive unions\n  - inline response/array/map unions\n  - / without discriminator\n  -  composition sample\n- **tests**: register new union scenarios in ; merge upstream tag tests; resolve minor conflict\n- **docs**: no changes\n\nImpact: broader OpenAPI compatibility without breaking changes; users get warnings when dynamic fallback is used.