### PR TITLE
fix: map tags to lowerCase on include or exclude check

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -1932,16 +1932,23 @@ class OpenApiParser {
   /// If both are empty, the path will always be included.
   bool _isPathIncluded(Map<String, dynamic> requestPath) {
     final tags = switch (requestPath[_tagsConst]) {
-      final List<dynamic> tags => tags.map((tag) => tag as String).toList(),
+      final List<dynamic> tags => tags
+          .map((tag) => tag as String)
+          .map((tag) => tag.toLowerCase())
+          .toList(),
       _ => <String>[],
     };
 
     if (config.includeTags.isNotEmpty) {
-      return config.includeTags.any(tags.contains);
+      return config.includeTags
+          .map((tag) => tag.toLowerCase())
+          .any(tags.contains);
     }
 
     if (config.excludeTags.isNotEmpty) {
-      return config.excludeTags.none(tags.contains);
+      return config.excludeTags
+          .map((tag) => tag.toLowerCase())
+          .none(tags.contains);
     }
 
     // If neither includeTags nor excludeTags is specified, include everything


### PR DESCRIPTION
### Summary

upon filtering tags map all to lowerCase to allow case insensitive filtering