### PR TITLE
Fix - issue 369

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -836,6 +836,8 @@ class OpenApiParser {
           return;
         }
 
+        _anchorRegistry.markContextAsIncluded(_contextStack.current!);
+
         value as Map<String, dynamic>;
 
         // Track schema dependencies for filtering

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -1932,16 +1932,23 @@ class OpenApiParser {
   /// If both are empty, the path will always be included.
   bool _isPathIncluded(Map<String, dynamic> requestPath) {
     final tags = switch (requestPath[_tagsConst]) {
-      final List<dynamic> tags => tags.map((tag) => tag as String).toList(),
+      final List<dynamic> tags => tags
+          .map((tag) => tag as String)
+          .map((tag) => tag.toLowerCase())
+          .toList(),
       _ => <String>[],
     };
 
     if (config.includeTags.isNotEmpty) {
-      return config.includeTags.any(tags.contains);
+      return config.includeTags
+          .map((tag) => tag.toLowerCase())
+          .any(tags.contains);
     }
 
     if (config.excludeTags.isNotEmpty) {
-      return config.excludeTags.none(tags.contains);
+      return config.excludeTags
+          .map((tag) => tag.toLowerCase())
+          .none(tags.contains);
     }
 
     // If neither includeTags nor excludeTags is specified, include everything


### PR DESCRIPTION
## Summary 

this is a fix to the issue mentioned in #369 that will ensure that nested objects in Schemas do get generated when using tag filters.

## Limitations

it will include any nested object in any Schema, also Schemas that are not referenced in any of the filtered path.