### PR TITLE
fix: resolve inline schemas nested within tagged operations

### DIFF
--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -536,6 +536,21 @@ void main() {
       );
     });
 
+    // https://github.com/Carapacik/swagger_parser/issues/369
+    test('tag_filtering_nested_objects', () async {
+      await e2eTest(
+        'tag_filtering_nested_objects',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          includeTags: ['include'],
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
     test('use_freezed3.3.0', () async {
       await e2eTest(
         'basic/use_freezed3.3.0',

--- a/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/export.dart
@@ -8,5 +8,6 @@ export 'clients/users_client.dart';
 export 'models/user.dart';
 export 'models/post.dart';
 export 'models/comment.dart';
+export 'models/user_status.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/models/user_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/models/user_status.dart
@@ -1,0 +1,34 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum UserStatus {
+  @JsonValue('ACTIVE')
+  active('ACTIVE'),
+  @JsonValue('INACTIVE')
+  inactive('INACTIVE'),
+  @JsonValue('SUSPENDED')
+  suspended('SUSPENDED'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const UserStatus(this.json);
+
+  factory UserStatus.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<UserStatus> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/export.dart
@@ -10,5 +10,6 @@ export 'models/pet.dart';
 export 'models/category.dart';
 export 'models/get_api_v1_no_tags_response.dart';
 export 'models/get_api_v1_empty_tags_response.dart';
+export 'models/pet_status.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/models/pet_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/models/pet_status.dart
@@ -1,0 +1,34 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum PetStatus {
+  @JsonValue('AVAILABLE')
+  available('AVAILABLE'),
+  @JsonValue('ADOPTED')
+  adopted('ADOPTED'),
+  @JsonValue('PENDING')
+  pending('PENDING'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const PetStatus(this.json);
+
+  factory PetStatus.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<PetStatus> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/basic/include_exclude_tags_with_schemas/expected_files/models/user_role.dart
+++ b/swagger_parser/test/e2e/tests/basic/include_exclude_tags_with_schemas/expected_files/models/user_role.dart
@@ -1,0 +1,36 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum UserRole {
+  @JsonValue('ADMIN')
+  admin('ADMIN'),
+  @JsonValue('USER')
+  user('USER'),
+  @JsonValue('MODERATOR')
+  moderator('MODERATOR'),
+  @JsonValue('GUEST')
+  guest('GUEST'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const UserRole(this.json);
+
+  factory UserRole.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<UserRole> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/export.dart
@@ -7,5 +7,6 @@ export 'clients/pets_client.dart';
 // Data classes
 export 'models/pet.dart';
 export 'models/category.dart';
+export 'models/pet_availability.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/models/pet_availability.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/models/pet_availability.dart
@@ -1,0 +1,36 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum PetAvailability {
+  @JsonValue('IN_STOCK')
+  inStock('IN_STOCK'),
+  @JsonValue('OUT_OF_STOCK')
+  outOfStock('OUT_OF_STOCK'),
+  @JsonValue('RESERVED')
+  reserved('RESERVED'),
+  @JsonValue('SOLD')
+  sold('SOLD'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const PetAvailability(this.json);
+
+  factory PetAvailability.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<PetAvailability> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/clients/include_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/clients/include_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/debug_schema.dart';
+
+part 'include_client.g.dart';
+
+@RestApi()
+abstract class IncludeClient {
+  factory IncludeClient(Dio dio, {String? baseUrl}) = _IncludeClient;
+
+  @GET('/api/v1/debug')
+  Future<DebugSchema> getDebug();
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/export.dart
@@ -3,13 +3,11 @@
 // ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
 
 // Clients
-export 'clients/pets_client.dart';
-export 'clients/users_client.dart';
+export 'clients/include_client.dart';
 // Data classes
-export 'models/pet.dart';
-export 'models/category.dart';
-export 'models/user.dart';
-export 'models/user_profile.dart';
-export 'models/user_role.dart';
+export 'models/debug_schema.dart';
+export 'models/metadata.dart';
+export 'models/data.dart';
+export 'models/status.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/data.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/data.dart
@@ -1,0 +1,23 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'status.dart';
+import 'metadata.dart';
+
+part 'data.freezed.dart';
+part 'data.g.dart';
+
+@Freezed()
+class Data with _$Data {
+  const factory Data({
+    String? name,
+    int? id,
+    Status? status,
+    Metadata? metadata,
+  }) = _Data;
+
+  factory Data.fromJson(Map<String, Object?> json) => _$DataFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/debug_schema.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/debug_schema.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'data.dart';
+
+part 'debug_schema.freezed.dart';
+part 'debug_schema.g.dart';
+
+@Freezed()
+class DebugSchema with _$DebugSchema {
+  const factory DebugSchema({
+    int? id,
+    String? message,
+    Data? data,
+  }) = _DebugSchema;
+
+  factory DebugSchema.fromJson(Map<String, Object?> json) =>
+      _$DebugSchemaFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/metadata.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/metadata.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'metadata.freezed.dart';
+part 'metadata.g.dart';
+
+@Freezed()
+class Metadata with _$Metadata {
+  const factory Metadata({
+    DateTime? createdAt,
+    String? updatedBy,
+  }) = _Metadata;
+
+  factory Metadata.fromJson(Map<String, Object?> json) =>
+      _$MetadataFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/status.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/status.dart
@@ -1,0 +1,34 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum Status {
+  @JsonValue('active')
+  active('active'),
+  @JsonValue('inactive')
+  inactive('inactive'),
+  @JsonValue('pending')
+  pending('pending'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const Status(this.json);
+
+  factory Status.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<Status> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/rest_client.dart
@@ -1,0 +1,28 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/include_client.dart';
+
+/// Tag Filtering Nested Objects API `v1.0.0`.
+///
+/// Test case for reproducing GitHub issue.
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  IncludeClient? _include;
+
+  IncludeClient get include =>
+      _include ??= IncludeClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/openapi.yaml
@@ -1,0 +1,70 @@
+openapi: 3.1.0
+info:
+  title: Tag Filtering Nested Objects API
+  version: 1.0.0
+  description: Test case for reproducing GitHub issue #369 - tag filtering prevents class generation for inline nested objects
+paths:
+  /api/v1/debug:
+    get:
+      operationId: getDebug
+      tags:
+        - include
+      responses:
+        '200':
+          description: Debug information with nested data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DebugSchema'
+  /api/v1/excluded:
+    get:
+      operationId: getExcluded  
+      tags:
+        - exclude
+      responses:
+        '200':
+          description: Excluded endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExcludedSchema'
+components:
+  schemas:
+    DebugSchema:
+      type: object
+      properties:
+        id:
+          type: integer
+        message:
+          type: string
+        data:
+          type: object
+          properties:
+            name:
+              type: string
+            id:
+              type: integer
+            status:
+              type: string
+              enum:
+                - active
+                - inactive
+                - pending
+            metadata:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  format: date-time
+                updatedBy:
+                  type: string
+    ExcludedSchema:
+      type: object
+      properties:
+        info:
+          type: string
+        details:
+          type: object
+          properties:
+            excluded:
+              type: boolean


### PR DESCRIPTION
## Summary

- Fixes issue where inline schemas defined within operations that have included tags were not being properly resolved and generated
- The AnchorRegistry now correctly identifies and includes nested inline schemas when their parent operations are included via tag filtering  
- Adds comprehensive test case `tag_filtering_nested_objects` to verify the fix
- Updates expected files for existing tests that now properly generate previously missing model files

## Changes

### Core Fix
- Enhanced `lib/src/parser/utils/anchor_registry.dart` to resolve inline schemas that are transitively reachable from included schemas
- Added logic to check if inline schemas are defined within a schema context that's already included

### Testing  
- Added new E2E test case `tag_filtering_nested_objects` with comprehensive OpenAPI spec
- Updated expected files for 4 existing test cases that now generate previously missing models:
  - `circular_deps_with_tags` - now generates `user_status.dart`
  - `excluded_tags_with_schemas` - now generates `pet_status.dart`  
  - `include_exclude_tags_with_schemas` - now generates `user_role.dart`
  - `included_tags_with_schemas` - now generates `pet_availability.dart`

## Test Plan

- [x] All existing E2E tests pass
- [x] New `tag_filtering_nested_objects` test passes  
- [x] Updated expected files for affected test cases
- [x] Manual verification of generated code quality

Closes #369