### PR TITLE
fix: Handle nullable discriminator unions properly

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -1569,6 +1569,7 @@ class OpenApiParser {
           ofType = UniversalType(
             type: newName.toPascal,
             isRequired: isRequired,
+            nullable: map[_nullableConst].toString().toBool() ?? false,
             // Nullability for ofType will be determined later by nullItems check
           );
           ofImport = newName.toPascal;
@@ -1774,8 +1775,8 @@ class OpenApiParser {
             ofList.every((item) =>
                 item is Map<String, dynamic> &&
                 item[_typeConst]?.toString() == 'null')) {
-          ofType = UniversalType(
-              type: _objectConst, isRequired: isRequired, nullable: true);
+          ofType = const UniversalType(
+              type: _objectConst, isRequired: false, nullable: true);
         } else {
           ofType ??= UniversalType(
             type: _objectConst,

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'test_data_type_type.dart';
+import 'test_entity_data_union.dart';
+
+part 'test_data_type.freezed.dart';
+part 'test_data_type.g.dart';
+
+@Freezed()
+class TestDataType with _$TestDataType {
+  const factory TestDataType({
+    /// Test value
+    required String value,
+    TestDataTypeType? type,
+  }) = _TestDataType;
+  
+  factory TestDataType.fromJson(Map<String, Object?> json) => _$TestDataTypeFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type.dart
@@ -17,6 +17,7 @@ class TestDataType with _$TestDataType {
     required String value,
     TestDataTypeType? type,
   }) = _TestDataType;
-  
-  factory TestDataType.fromJson(Map<String, Object?> json) => _$TestDataTypeFromJson(json);
+
+  factory TestDataType.fromJson(Map<String, Object?> json) =>
+      _$TestDataTypeFromJson(json);
 }

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
@@ -1,0 +1,27 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum TestDataTypeType {
+  @JsonValue('TEST_TYPE')
+  testType('TEST_TYPE'),
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const TestDataTypeType(this.json);
+
+  factory TestDataTypeType.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json ?? super.toString();
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<TestDataTypeType> get $valuesDefined => values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
@@ -8,6 +8,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 enum TestDataTypeType {
   @JsonValue('TEST_TYPE')
   testType('TEST_TYPE'),
+
   /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
   $unknown(null);
 
@@ -22,6 +23,8 @@ enum TestDataTypeType {
 
   @override
   String toString() => json ?? super.toString();
+
   /// Returns all defined enum values excluding the $unknown value.
-  static List<TestDataTypeType> get $valuesDefined => values.where((value) => value != $unknown).toList();
+  static List<TestDataTypeType> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
 }

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'test_entity_data_union.dart';
+
+part 'test_entity.freezed.dart';
+part 'test_entity.g.dart';
+
+@Freezed()
+class TestEntity with _$TestEntity {
+  const factory TestEntity({
+    /// Test ID
+    required String id,
+
+    /// Test name
+    required String name,
+
+    /// Test data
+    TestEntityDataUnion? data,
+  }) = _TestEntity;
+  
+  factory TestEntity.fromJson(Map<String, Object?> json) => _$TestEntityFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity.dart
@@ -21,6 +21,7 @@ class TestEntity with _$TestEntity {
     /// Test data
     TestEntityDataUnion? data,
   }) = _TestEntity;
-  
-  factory TestEntity.fromJson(Map<String, Object?> json) => _$TestEntityFromJson(json);
+
+  factory TestEntity.fromJson(Map<String, Object?> json) =>
+      _$TestEntityFromJson(json);
 }

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity_data_union.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity_data_union.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'test_data_type.dart';
+import 'test_data_type_type.dart';
+
+part 'test_entity_data_union.freezed.dart';
+part 'test_entity_data_union.g.dart';
+
+@Freezed(unionKey: 'type')
+sealed class TestEntityDataUnion with _$TestEntityDataUnion {
+  @FreezedUnionValue('TEST_TYPE')
+  const factory TestEntityDataUnion.testType({
+    /// Test value
+    required String value,
+    TestDataTypeType? type,
+  }) = TestEntityDataUnionTestType;
+
+  
+  factory TestEntityDataUnion.fromJson(Map<String, Object?> json) => _$TestEntityDataUnionFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity_data_union.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_entity_data_union.dart
@@ -19,6 +19,6 @@ sealed class TestEntityDataUnion with _$TestEntityDataUnion {
     TestDataTypeType? type,
   }) = TestEntityDataUnionTestType;
 
-  
-  factory TestEntityDataUnion.fromJson(Map<String, Object?> json) => _$TestEntityDataUnionFromJson(json);
+  factory TestEntityDataUnion.fromJson(Map<String, Object?> json) =>
+      _$TestEntityDataUnionFromJson(json);
 }

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/nullable_discriminator.json
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/nullable_discriminator.json
@@ -1,0 +1,56 @@
+{
+	"openapi": "3.1.0",
+	"info": {
+		"title": "Nullable Discriminator API",
+		"version": "1.0.0"
+	},
+	"paths": {},
+	"components": {
+		"schemas": {
+			"TestEntity": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "Test ID"
+					},
+					"name": {
+						"type": "string",
+						"description": "Test name"
+					},
+					"data": {
+						"description": "Test data",
+						"oneOf": [
+							{
+								"$ref": "#/components/schemas/TestDataType"
+							}
+						],
+						"discriminator": {
+							"propertyName": "type",
+							"mapping": {
+								"TEST_TYPE": "#/components/schemas/TestDataType"
+							}
+						},
+						"nullable": true
+					}
+				},
+				"required": ["id", "name"]
+			},
+			"TestDataType": {
+				"type": "object",
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": ["TEST_TYPE"],
+						"nullable": true
+					},
+					"value": {
+						"type": "string",
+						"description": "Test value"
+					}
+				},
+				"required": ["value"]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 🐛 Problem
When OpenAPI schemas define discriminated unions (oneOf/anyOf) with `nullable: true`, the generated Dart code incorrectly produces `required Type data` instead of the expected `Type? data`, causing compilation errors.

## ✅ Solution
- Add nullable property handling for discriminated oneOf/anyOf unions
- Set isRequired to false for null-only schemas  
- Add test case for nullable discriminator scenarios
- Fixes issue where nullable discriminator unions were incorrectly generated as required

## 🧪 Testing
- Added comprehensive test case in `test/e2e/tests/basic/nullable_discriminator/`
- Test covers nullable discriminator union scenarios
- All existing tests continue to pass
- Verified the fix generates correct `Type? data` syntax

## ✅ Code Quality
- Code formatted with `dart format .`
- Code analyzed with `dart analyze` - no issues found
- All status checks passing

## 📝 Example
**Before (broken):**
```dart
const factory TestEntity({
  TestEntityDataUnion data,  // ❌ Error
}) = _TestEntity;
```

**After (fixed):**
```dart
const factory TestEntity({
  TestEntityDataUnion? data,  // ✅ Correct
}) = _TestEntity;
```