### PR TITLE
Fix: Preserve correct subtype typing for this in sealed class switch expressions

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
@@ -253,7 +253,7 @@ String _toJsonUndiscriminatedUnion(
 ) {
   final cases = {
     for (final variant in undiscriminatedUnionVariants.keys)
-      '        $className${variant.toPascal}() => _\$\$$className${variant.toPascal}ImplToJson(this),'
+      '        $className${variant.toPascal}() => _\$$className${variant.toPascal}ToJson(this as $className${variant.toPascal}),'
   };
 
   return '''


### PR DESCRIPTION
This PR fixes an issue where switch expressions over sealed class unions did not properly narrow the type of this to the matched subtype.

In Dart, this does not automatically change its static type inside a switch pattern case — even when the case pattern matches a specific subclass. As a result, generated code that directly passed this to subtype-specific serialization functions (e.g. _$SubtypeToJson(this)) failed to compile without explicit casting.

This PR updates the code generation logic to ensure the correct subtype is used in these cases by explicitly binding or casting this to the appropriate subclass within each switch case.