### PR TITLE
fix: update parser to handle apostrophes gracefully

### DIFF
--- a/swagger_parser/lib/src/parser/model/normalized_identifier.dart
+++ b/swagger_parser/lib/src/parser/model/normalized_identifier.dart
@@ -27,7 +27,11 @@ class NormalizedIdentifier {
       return NormalizedIdentifier._([], isPrivate: isPrivate);
     }
 
-    final words = _parseWords(workingText);
+    // Remove apostrophes before parsing so they don't split words
+    // e.g., "What's New" becomes "Whats New" -> ["Whats", "New"]
+    final textWithoutApostrophes = workingText.replaceAll("'", '');
+
+    final words = _parseWords(textWithoutApostrophes);
     return NormalizedIdentifier._(words, isPrivate: isPrivate);
   }
 

--- a/swagger_parser/test/e2e/tests/basic/tags/expected_files/clients/whats_new_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/tags/expected_files/clients/whats_new_client.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_whats_new_items_response.dart';
+
+part 'whats_new_client.g.dart';
+
+@RestApi()
+abstract class WhatsNewClient {
+  factory WhatsNewClient(Dio dio, {String? baseUrl}) = _WhatsNewClient;
+
+  /// Get what's new items
+  @GET('/whats-new/items')
+  Future<List<GetWhatsNewItemsResponse>> getWhatsNewItems();
+}

--- a/swagger_parser/test/e2e/tests/basic/tags/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/basic/tags/expected_files/export.dart
@@ -6,9 +6,11 @@
 export 'clients/fallback_client.dart';
 export 'clients/client2_client.dart';
 export 'clients/parcel_pending_client.dart';
+export 'clients/whats_new_client.dart';
 // Data classes
 export 'models/api_parcel_pending_building_settings.dart';
 export 'models/api_parcel_pending_building_settings_request.dart';
 export 'models/get_parcel_pending_webhook_buildings_building_id_response.dart';
+export 'models/get_whats_new_items_response.dart';
 // Root client
 export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/basic/tags/expected_files/models/get_whats_new_items_response.dart
+++ b/swagger_parser/test/e2e/tests/basic/tags/expected_files/models/get_whats_new_items_response.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_whats_new_items_response.freezed.dart';
+part 'get_whats_new_items_response.g.dart';
+
+@Freezed()
+class GetWhatsNewItemsResponse with _$GetWhatsNewItemsResponse {
+  const factory GetWhatsNewItemsResponse({
+    @JsonKey(includeIfNull: false) String? id,
+    @JsonKey(includeIfNull: false) String? title,
+  }) = _GetWhatsNewItemsResponse;
+
+  factory GetWhatsNewItemsResponse.fromJson(Map<String, Object?> json) =>
+      _$GetWhatsNewItemsResponseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/basic/tags/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/tags/expected_files/rest_client.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'clients/fallback_client.dart';
 import 'clients/client2_client.dart';
 import 'clients/parcel_pending_client.dart';
+import 'clients/whats_new_client.dart';
 
 ///  `v0.0.0 (v1)`
 class RestClient {
@@ -24,6 +25,7 @@ class RestClient {
   FallbackClient? _fallback;
   Client2Client? _client2;
   ParcelPendingClient? _parcelPending;
+  WhatsNewClient? _whatsNew;
 
   FallbackClient get fallback =>
       _fallback ??= FallbackClient(_dio, baseUrl: _baseUrl);
@@ -33,4 +35,7 @@ class RestClient {
 
   ParcelPendingClient get parcelPending =>
       _parcelPending ??= ParcelPendingClient(_dio, baseUrl: _baseUrl);
+
+  WhatsNewClient get whatsNew =>
+      _whatsNew ??= WhatsNewClient(_dio, baseUrl: _baseUrl);
 }

--- a/swagger_parser/test/e2e/tests/basic/tags/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/basic/tags/openapi.yaml
@@ -85,6 +85,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiParcelPendingBuildingSettings'
 
+  /whats-new/items:
+    get:
+      tags:
+        - What's New
+      summary: Get what's new items
+      operationId: getWhatsNewItems
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+
 components:
   schemas:
     ApiParcelPendingBuildingSettings:


### PR DESCRIPTION
Parses tags with apostrophe like "What's New" gracefully by removing apostrophes before processing.