### PR TITLE
Fix enum name values being a int returned in a toString

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -178,7 +178,7 @@ String _toJson(UniversalEnumClass enumClass, String className) {
 }
 
 String _toString() =>
-    '\n\n  @override\n  String toString() => json ?? super.toString();';
+    '\n\n  @override\n  String toString() => json?.toString() ?? super.toString();';
 
 String _toStringDartMappable() =>
     '\n\n  @override\n  String toString() => toValue().toString();\n';

--- a/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/models/user_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/circular_deps_with_tags/expected_files/models/user_status.dart
@@ -26,7 +26,7 @@ enum UserStatus {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<UserStatus> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/enum_class/expected_files/models/class_name_status.dart
@@ -26,7 +26,7 @@ enum ClassNameStatus {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<ClassNameStatus> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/models/status.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags/expected_files/models/status.dart
@@ -28,7 +28,7 @@ enum Status {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Status> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/models/pet_status.dart
+++ b/swagger_parser/test/e2e/tests/basic/excluded_tags_with_schemas/expected_files/models/pet_status.dart
@@ -26,7 +26,7 @@ enum PetStatus {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<PetStatus> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/include_exclude_tags_with_schemas/expected_files/models/user_role.dart
+++ b/swagger_parser/test/e2e/tests/basic/include_exclude_tags_with_schemas/expected_files/models/user_role.dart
@@ -28,7 +28,7 @@ enum UserRole {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<UserRole> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/models/level.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_and_excluded_tags/expected_files/models/level.dart
@@ -28,7 +28,7 @@ enum Level {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Level> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/models/category.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags/expected_files/models/category.dart
@@ -28,7 +28,7 @@ enum Category {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Category> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/models/pet_availability.dart
+++ b/swagger_parser/test/e2e/tests/basic/included_tags_with_schemas/expected_files/models/pet_availability.dart
@@ -28,7 +28,7 @@ enum PetAvailability {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<PetAvailability> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
+++ b/swagger_parser/test/e2e/tests/basic/nullable_discriminator/expected_files/models/test_data_type_type.dart
@@ -22,7 +22,7 @@ enum TestDataTypeType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<TestDataTypeType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/new_pet_dto_action_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.2.0/expected_files/models/new_pet_dto_action_dto.dart
@@ -26,7 +26,7 @@ enum NewPetDtoActionDto {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<NewPetDtoActionDto> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/enum0_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/enum0_dto.dart
@@ -27,7 +27,7 @@ enum Enum0Dto {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Enum0Dto> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/p2_enum_dto.dart
+++ b/swagger_parser/test/e2e/tests/basic/replacement_rules.3.1/expected_files/models/p2_enum_dto.dart
@@ -26,7 +26,7 @@ enum P2EnumDto {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<P2EnumDto> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/models/enum0_dto.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/models/enum0_dto.dart
@@ -27,7 +27,7 @@ enum Enum0Dto {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Enum0Dto> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/corrector/expected_files/models/p2_enum_dto.dart
+++ b/swagger_parser/test/e2e/tests/corrector/expected_files/models/p2_enum_dto.dart
@@ -26,7 +26,7 @@ enum P2EnumDto {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<P2EnumDto> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_member_names/expected_files/models/enum_class.dart
+++ b/swagger_parser/test/e2e/tests/enum_member_names/expected_files/models/enum_class.dart
@@ -57,7 +57,7 @@ enum EnumClass {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumClass> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_member_names/expected_files/models/x_enum_names.dart
+++ b/swagger_parser/test/e2e/tests/enum_member_names/expected_files/models/x_enum_names.dart
@@ -26,7 +26,7 @@ enum XEnumNames {
   final num? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<XEnumNames> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/credential_types.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/credential_types.dart
@@ -24,7 +24,7 @@ enum CredentialTypes {
   final dynamic json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CredentialTypes> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/enum_class.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/enum_class.dart
@@ -61,7 +61,7 @@ enum EnumClass {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumClass> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/enum_class_dynamic.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/enum_class_dynamic.dart
@@ -57,7 +57,7 @@ enum EnumClassDynamic {
   final dynamic json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumClassDynamic> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/fruits.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list/expected_files/models/fruits.dart
@@ -28,7 +28,7 @@ enum Fruits {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Fruits> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/pet_status.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/pet_status.dart
@@ -27,7 +27,7 @@ enum PetStatus {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<PetStatus> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/status.dart
+++ b/swagger_parser/test/e2e/tests/nullable_types.2.0/expected_files/models/status.dart
@@ -26,7 +26,7 @@ enum Status {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Status> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/status.dart
+++ b/swagger_parser/test/e2e/tests/tag_filtering_nested_objects/expected_files/models/status.dart
@@ -26,7 +26,7 @@ enum Status {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<Status> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_json_serializable/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of_json_serializable/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/cat_type.dart
@@ -22,7 +22,7 @@ enum CatType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<CatType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/dog_type.dart
@@ -22,7 +22,7 @@ enum DogType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<DogType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_json_serializable/expected_files/models/human_type.dart
@@ -22,7 +22,7 @@ enum HumanType {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<HumanType> get $valuesDefined =>

--- a/swagger_parser/test/e2e/tests/xof/of_like_class.3.1/expected_files/models/enum_class.dart
+++ b/swagger_parser/test/e2e/tests/xof/of_like_class.3.1/expected_files/models/enum_class.dart
@@ -24,7 +24,7 @@ enum EnumClass {
   final String? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumClass> get $valuesDefined =>

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1667,7 +1667,7 @@ enum EnumName {
   int? toJson() => json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 }
 ''';
 
@@ -1692,7 +1692,7 @@ enum EnumNameString {
   String? toJson() => json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
 }
 ''';
 
@@ -1845,7 +1845,7 @@ enum EnumName {
   int? toJson() => json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumName> get $valuesDefined => values.where((value) => value != $unknown).toList();
 }
@@ -1881,7 +1881,7 @@ enum EnumNameString {
   String? toJson() => json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumNameString> get $valuesDefined => values.where((value) => value != $unknown).toList();
 }
@@ -2018,7 +2018,7 @@ enum EnumName {
   final int? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumName> get $valuesDefined => values.where((value) => value != $unknown).toList();
 }
@@ -2068,7 +2068,7 @@ enum EnumName {
   final int? json;
 
   @override
-  String toString() => json ?? super.toString();
+  String toString() => json?.toString() ?? super.toString();
   /// Returns all defined enum values excluding the $unknown value.
   static List<EnumName> get $valuesDefined => values.where((value) => value != $unknown).toList();
 }


### PR DESCRIPTION
In the case where enum generation would contain a "int?" json property, returning a plain json on toString() will cause an error.