### PR TITLE
Feat: proper support for streaming & SSE

### DIFF
--- a/swagger_parser/test/e2e/tests/basic/file_download/expected_files/clients/file_client.dart
+++ b/swagger_parser/test/e2e/tests/basic/file_download/expected_files/clients/file_client.dart
@@ -2,6 +2,8 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
 
+import 'dart:convert';
+import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -13,8 +15,8 @@ abstract class FileClient {
 
   /// Download a file
   @GET('/files/{id}')
-  @DioResponseType(ResponseType.bytes)
-  Future<HttpResponse<List<int>>> downloadFile({
+  @DioResponseType(ResponseType.stream)
+  Stream<String> downloadFile({
     @Path('id') required String id,
   });
 }


### PR DESCRIPTION
This PR adds proper utilization and support of the [_Streaming and Server-Sent Events (SSE)_](https://github.com/trevorwang/retrofit.dart/tree/master#streaming-and-server-sent-events-sse) feature from [retrofit.dart](https://github.com/trevorwang/retrofit.dart).