### PR TITLE
fix: dart_mappable default enum value

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -84,7 +84,7 @@ String _dartEnumDartMappableTemplate(
       .join(',\n');
 
   final annotationParameters = [
-    if (unknownEnumValue) "defaultValue: 'unknown'",
+    if (unknownEnumValue) 'defaultValue: $className.unknown',
   ].join(', ');
 
   final enumBodyParts = [

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/cat_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'cat_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: CatType.unknown)
 enum CatType {
   @MappableValue('Cat')
   cat,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/dog_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'dog_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: DogType.unknown)
 enum DogType {
   @MappableValue('Dog')
   dog,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_any_of_complete_mapping_mappable/expected_files/models/human_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'human_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: HumanType.unknown)
 enum HumanType {
   @MappableValue('Human')
   human,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/android_device_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/android_device_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'android_device_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: AndroidDeviceType.unknown)
 enum AndroidDeviceType {
   @MappableValue('android')
   android,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/cat_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'cat_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: CatType.unknown)
 enum CatType {
   @MappableValue('Cat')
   cat,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/dog_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'dog_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: DogType.unknown)
 enum DogType {
   @MappableValue('Dog')
   dog,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/human_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'human_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: HumanType.unknown)
 enum HumanType {
   @MappableValue('Human')
   human,

--- a/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/ios_device_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/discriminated_one_of.3.0_mappable/expected_files/models/ios_device_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'ios_device_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: IosDeviceType.unknown)
 enum IosDeviceType {
   @MappableValue('ios')
   ios,

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/cat_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'cat_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: CatType.unknown)
 enum CatType {
   @MappableValue('Cat')
   cat,

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/dog_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'dog_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: DogType.unknown)
 enum DogType {
   @MappableValue('Dog')
   dog,

--- a/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/human_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/fallback_union_mappable/expected_files/models/human_type.dart
@@ -6,7 +6,7 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 part 'human_type.mapper.dart';
 
-@MappableEnum(defaultValue: 'unknown')
+@MappableEnum(defaultValue: HumanType.unknown)
 enum HumanType {
   @MappableValue('Human')
   human,


### PR DESCRIPTION
This PR fixes enum generation for dart_mappable when `unknown_enum_value: true` is enabled.

**Problem**

Generated enums were emitting: `@MappableEnum(defaultValue: 'unknown')`.

However, `dart_mappable` expects the actual enum case, not the serialized string value. Because of this, the generated mapper could not resolve the fallback enum index and still generated a throwing decode path for unknown backend values.

This caused older clients to crash when the backend introduced a new enum value.


**Fix**
The generator now emits the proper enum case reference instead of the encoded string value:

```@MappableEnum(defaultValue: AnnouncementType.unknown)```

This restores the expected dart_mappable behavior where unknown enum values safely fall back to the generated unknown enum case instead of throwing MapperException.unknownEnumValue(value).

**Current behavior**

It looks like @MappableEnum(defaultValue: ...) does not fallback when decoding an unknown enum value, and instead still throws MapperException.unknownEnumValue(...).

**Example**

This enum:

```
import 'package:dart_mappable/dart_mappable.dart';

part 'test.mapper.dart';

@MappableEnum(defaultValue: 'unknown')
enum Test {
  @MappableValue('info')
  info,

  @MappableValue('feature')
  feature,

  @MappableValue('unknown')
  unknown,
}
```

generates

```
@override
Test decode(dynamic value) {
  switch (value) {
    case 'info':
      return Test.info;
    case 'feature':
      return Test.feature;
    case 'unknown':
      return Test.unknown;
    default:
      throw MapperException.unknownEnumValue(value);
  }
}
```

**Problem**

If the backend later returns a new enum value, for example: `{ "type": "education" }` decoding fails with: `MapperException.unknownEnumValue(value)` instead of falling back to: `Test.unknown`.


**Expected behavior**

When defaultValue is set, I would expect unknown enum values to decode to that default value, e.g.: 

```
default:
  return Test.unknown;
```

This is especially important for API clients, where backend enums may evolve over time and older app versions should remain backward-compatible instead of crashing on new enum values.
