### PR TITLE
Fix freezed issue

### DIFF
--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -193,9 +193,12 @@ final class FillController {
       buffer.writeln();
     }
 
+    if (config.jsonSerializer == JsonSerializer.freezed) {
+      buffer.writeln(
+        "part '${config.name}.freezed.${config.language.fileExtension}';",
+      );
+    }
     buffer
-      ..writeln(
-          "part '${config.name}.freezed.${config.language.fileExtension}';")
       ..writeln("part '${config.name}.g.${config.language.fileExtension}';")
       ..writeln();
 

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -1076,6 +1076,22 @@ void main() {
       );
     });
 
+    test('merged_outputs_json_serializable', () async {
+      await e2eTest(
+        'basic/merged_outputs_json_serializable',
+        (outputDirectory, schemaPath) => SWPConfig(
+          name: 'merged_outputs',
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.jsonSerializable,
+          useXNullable: true,
+          mergeOutputs: true,
+          includeIfNull: true,
+        ),
+        schemaFileName: 'merged_outputs.json',
+      );
+    });
+
     test('discriminated_one_of_json_serializable', () async {
       await e2eTest(
         'xof/discriminated_one_of_json_serializable',

--- a/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/merged_outputs.json
+++ b/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/merged_outputs.json
@@ -1,0 +1,159 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/api/Auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "consumes": [
+          "text/json",
+          "application/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/RegisterUserDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/api/User/info": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/UserInfoDto"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/User/{id}/avatar": {
+      "patch": {
+        "tags": [
+          "User"
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "avatar",
+            "type": "file"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "RegisterUserDto": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "password"
+      ]
+    },
+    "UserInfoDto": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "phone"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The Bug:

When using merge_outputs: true with json_serializer: json_serializable, the generated file incorrectly includes:

part 'ffs_api.freezed.dart';
part 'ffs_api.g.dart';
It should only include:

part 'ffs_api.g.dart';
Why it's wrong:

json_serializable only needs .g.dart files (for @JsonSerializable classes)
freezed needs both .freezed.dart and .g.dart files (for @Freezed classes)
The code generator correctly uses @JsonSerializable annotations (not @Freezed)
But the part directive for freezed is still being added
Where the bug likely is:

The merged file template unconditionally adds part 'filename.freezed.dart' regardless of which json_serializer is configured. It should only add that line when json_serializer: freezed.

Evidence:

With merge_outputs: false, each file correctly only has part 'filename.g.dart'
With merge_outputs: true, the freezed part directive appears even with json_serializer: json_serializable