### PR TITLE
Fix issue with generated code when using json_serializer

### DIFF
--- a/swagger_parser/lib/src/generator/generator/fill_controller.dart
+++ b/swagger_parser/lib/src/generator/generator/fill_controller.dart
@@ -193,9 +193,12 @@ final class FillController {
       buffer.writeln();
     }
 
+    if (config.jsonSerializer == JsonSerializer.freezed) {
+      buffer.writeln(
+        "part '${config.name}.freezed.${config.language.fileExtension}';",
+      );
+    }
     buffer
-      ..writeln(
-          "part '${config.name}.freezed.${config.language.fileExtension}';")
       ..writeln("part '${config.name}.g.${config.language.fileExtension}';")
       ..writeln();
 

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -1076,6 +1076,22 @@ void main() {
       );
     });
 
+    test('merged_outputs_json_serializable', () async {
+      await e2eTest(
+        'basic/merged_outputs_json_serializable',
+        (outputDirectory, schemaPath) => SWPConfig(
+          name: 'merged_outputs',
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.jsonSerializable,
+          useXNullable: true,
+          mergeOutputs: true,
+          includeIfNull: true,
+        ),
+        schemaFileName: 'merged_outputs.json',
+      );
+    });
+
     test('discriminated_one_of_json_serializable', () async {
       await e2eTest(
         'xof/discriminated_one_of_json_serializable',

--- a/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/expected_files/merged_outputs.dart
+++ b/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/expected_files/merged_outputs.dart
@@ -1,0 +1,101 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart' hide Headers;
+import 'package:dio/dio.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'merged_outputs.g.dart';
+
+@RestApi()
+abstract class AuthClient {
+  factory AuthClient(Dio dio, {String? baseUrl}) = _AuthClient;
+
+  @Headers(<String, String>{'Content-Type': 'text/json'})
+  @POST('/api/Auth/register')
+  Future<String> postApiAuthRegister({
+    @Body() RegisterUserDto? body,
+  });
+}
+
+@RestApi()
+abstract class UserClient {
+  factory UserClient(Dio dio, {String? baseUrl}) = _UserClient;
+
+  /// [tags] - tags to filter by.
+  ///
+  /// [limit] - maximum number of results to return.
+  @GET('/api/User/info')
+  Future<UserInfoDto> getApiUserInfo({
+    @Query('tags') List<String>? tags,
+    @Query('limit') int? limit,
+  });
+
+  @MultiPart()
+  @PATCH('/api/User/{id}/avatar')
+  Future<void> patchApiUserIdAvatar({
+    @Part(name: 'avatar') File? avatar,
+    @Path('id') int? id,
+  });
+}
+
+@JsonSerializable()
+class RegisterUserDto {
+  const RegisterUserDto({
+    required this.email,
+    required this.name,
+    required this.password,
+  });
+
+  factory RegisterUserDto.fromJson(Map<String, Object?> json) =>
+      _$RegisterUserDtoFromJson(json);
+
+  final String email;
+  final String name;
+  final String password;
+
+  Map<String, Object?> toJson() => _$RegisterUserDtoToJson(this);
+}
+
+@JsonSerializable()
+class UserInfoDto {
+  const UserInfoDto({
+    required this.email,
+    required this.name,
+    required this.phone,
+  });
+
+  factory UserInfoDto.fromJson(Map<String, Object?> json) =>
+      _$UserInfoDtoFromJson(json);
+
+  final String email;
+  final String name;
+  final String phone;
+
+  Map<String, Object?> toJson() => _$UserInfoDtoToJson(this);
+}
+
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '';
+
+  AuthClient? _auth;
+  UserClient? _user;
+
+  AuthClient get auth => _auth ??= AuthClient(_dio, baseUrl: _baseUrl);
+
+  UserClient get user => _user ??= UserClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/merged_outputs.json
+++ b/swagger_parser/test/e2e/tests/basic/merged_outputs_json_serializable/merged_outputs.json
@@ -1,0 +1,159 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/api/Auth/register": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "consumes": [
+          "text/json",
+          "application/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "$ref": "#/definitions/RegisterUserDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/api/User/info": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "consumes": [
+          "application/json",
+          "text/json",
+          "application/*+json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "type": "array",
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/UserInfoDto"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/User/{id}/avatar": {
+      "patch": {
+        "tags": [
+          "User"
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "avatar",
+            "type": "file"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "RegisterUserDto": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "password"
+      ]
+    },
+    "UserInfoDto": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "email",
+        "name",
+        "phone"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## The Bug
When using `merge_outputs: true` with `json_serializer: json_serializable`, the generated file incorrectly includes:

```Dart
part 'ffs_api.freezed.dart';
part 'ffs_api.g.dart';
```

It should only include:
```Dart
part 'ffs_api.g.dart';
```

## Why it's wrong
`json_serializable` only needs `.g.dart` files (for `@JsonSerializable` classes)
`freezed` needs both `.freezed.dart` and `.g.dart` files (for `@Freezed` classes)
The code generator correctly uses `@JsonSerializable` annotations (not `@Freezed`), but the `part` directive for `freezed` is still being added for both serializers.

## Cause
The merged file template unconditionally adds `part 'filename.freezed.dart'` regardless of which `json_serializer` is configured. It should only add that line when the configuration is `json_serializer: freezed`.

## Evidence:
With merge_outputs: false, each file correctly only has part 'filename.g.dart'
With merge_outputs: true, the freezed part directive appears even with json_serializer: json_serializable

## Tests
A test has been added to make sure the changes work as desired, and other tests continue to pass.

---
This PR was primarily done by @TDLehman, I just did the review and got the description cleaned up and entered.