### PR TITLE
fix: escape $unknown in generated enum toJson error message

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -197,7 +197,7 @@ String _toJson(UniversalEnumClass enumClass, String className) {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to $dartType. '
-          'This usually happens for \$unknown or @JsonValue(null) entries.');
+          'This usually happens for \\\$unknown or @JsonValue(null) entries.');
     }
     return value as $dartType;
   }''';

--- a/swagger_parser/test/generator/data_classes_test.dart
+++ b/swagger_parser/test/generator/data_classes_test.dart
@@ -1700,7 +1700,7 @@ enum EnumName {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to int. '
-          'This usually happens for $unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as int;
   }
@@ -1731,7 +1731,7 @@ enum EnumNameString {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for $unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }
@@ -1940,7 +1940,7 @@ enum EnumName {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to int. '
-          'This usually happens for $unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as int;
   }
@@ -1982,7 +1982,7 @@ enum EnumNameString {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for $unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }
@@ -2041,7 +2041,7 @@ enum Status {
     final value = json;
     if (value == null) {
       throw StateError('Cannot convert enum value with null JSON representation to String. '
-          'This usually happens for $unknown or @JsonValue(null) entries.');
+          'This usually happens for \$unknown or @JsonValue(null) entries.');
     }
     return value as String;
   }


### PR DESCRIPTION
The generated toJson() method for enums produced a string literal '...for $unknown or @JsonValue(null)...' inside a non-raw Dart string. Dart then interpreted $unknown as variable interpolation of `unknown`, which does not exist in scope, breaking compilation of every generated enum file when enums_to_json: true.

Escape the dollar sign in the template so the generated file contains \$unknown (a literal dollar followed by "unknown"), compiling correctly regardless of the unknown_enum_value setting.

Fixes #454