### PR TITLE
Feat: x-dart section in requests for Dart specific configs

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_retrofit_client_template.dart
@@ -175,9 +175,12 @@ String _toClientRequest(
     ..write('  $finalResponseType ')
     ..write('${request.name}(');
 
-  if (request.parameters.isNotEmpty ||
+  final hasParameters = request.parameters.isNotEmpty ||
       addExtrasParameter ||
-      addDioOptionsParameter) {
+      addDioOptionsParameter ||
+      request.configExtension.isCancelable;
+
+  if (hasParameters) {
     sb.write('{\n');
   }
 
@@ -193,10 +196,11 @@ String _toClientRequest(
   if (addDioOptionsParameter) {
     sb.write(_addDioOptionsParameter());
   }
+  if (request.configExtension.isCancelable) {
+    sb.write(_addDioCancelToken());
+  }
 
-  if (request.parameters.isNotEmpty ||
-      addExtrasParameter ||
-      addDioOptionsParameter) {
+  if (hasParameters) {
     sb.write('  });\n');
   } else {
     sb.write(');\n');
@@ -261,6 +265,9 @@ String _quoteJson(String value) =>
 
 String _addDioOptionsParameter() =>
     '    @DioOptions() RequestOptions? options,\n';
+
+String _addDioCancelToken() =>
+    '    @CancelRequest() CancelToken? cancelToken,\n';
 
 String _toParameter(UniversalRequestType parameter, bool useMultipartFile) {
   var parameterType = parameter.type.toSuitableType(

--- a/swagger_parser/lib/src/parser/model/universal_request.dart
+++ b/swagger_parser/lib/src/parser/model/universal_request.dart
@@ -19,6 +19,7 @@ final class UniversalRequest {
     this.contentType = 'application/json',
     this.description,
     this.isDeprecated = false,
+    this.configExtension = const UniversalRequestConfigExtension(),
   });
 
   /// Request name
@@ -60,6 +61,8 @@ final class UniversalRequest {
 
   /// Value indicating whether this request is deprecated
   final bool isDeprecated;
+
+  final UniversalRequestConfigExtension configExtension;
 
   @override
   bool operator ==(Object other) =>
@@ -138,4 +141,61 @@ enum HttpRequestType {
   /// Get type from string
   static HttpRequestType? fromString(String type) =>
       HttpRequestType.values.firstWhereOrNull((e) => e.name == type);
+}
+
+@immutable
+final class UniversalRequestConfigExtension {
+  const UniversalRequestConfigExtension({
+    bool? isCancelable,
+  }) : isCancelable = isCancelable ?? false;
+
+  factory UniversalRequestConfigExtension.parse(
+    Map<String, dynamic> requestConfig,
+  ) {
+    final xDart = requestConfig[_xDartSection] as Map<String, dynamic>?;
+    return UniversalRequestConfigExtension(
+      isCancelable: bool.tryParse(xDart?[_isCancelableKey]?.toString() ?? ''),
+    );
+  }
+
+  static const _xDartSection = 'x-dart';
+
+  /// Whether or not the request should be cancelable.
+  ///
+  /// True if the `cancelable` flag in the `x-dart` section has been set to
+  /// `true` for the specific request.
+  ///
+  /// ## Example
+  ///
+  /// ```yaml
+  /// paths:
+  ///   /path/variant4:
+  ///     get:
+  ///       x-dart:
+  ///         cancelable: true
+  ///       tags:
+  ///         - sse
+  ///       responses:
+  ///         200:
+  ///           content:
+  ///             application/octect-stream:
+  ///               schema:
+  ///                 type: integer
+  ///                 format: binary
+  /// ```
+  final bool isCancelable;
+  static const _isCancelableKey = 'cancelable';
+
+  @override
+  int get hashCode => isCancelable.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is UniversalRequestConfigExtension &&
+      other.isCancelable == isCancelable;
+
+  @override
+  String toString() => 'UniversalRequestConfigExtension('
+      'isCancelable: $isCancelable'
+      ')';
 }

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -709,6 +709,7 @@ class OpenApiParser {
             parameters: parameters,
             isDeprecated:
                 requestPath[_deprecatedConst].toString().toBool() ?? false,
+            configExtension: UniversalRequestConfigExtension.parse(requestPath),
           );
           // we are converting the tag to the snake case
           // later tag is used to determine the file name


### PR DESCRIPTION
Add the possibility to provide Dart specific configuration options per request in the OpenAPI schema. The user must add a `x-dart` section under their request method (e.g. `get`, `post`, ...) which then can contain multiple configuration values that will **only** be applied to the generated Dart code.

Currently the only option is the boolean flag `cancelable`, which determines whether or not a `CancelToken` for package `dio` should be added to the parameters of generated method for said request.