### PR TITLE
bugfix/preserve-casing-via-config

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.44.0
+
+- Add `preserve_schema_casing` option to preserve original casing of schema-derived identifiers, defaults to `false` for backwards compatibility, which normalises to PascalCase
+
 ## 1.43.1
 - Fix escaping `$unknown` in generated enum `toJson` error messages
 - Fix generated code when using `json_serializable`

--- a/swagger_parser/lib/src/config/swp_config.dart
+++ b/swagger_parser/lib/src/config/swp_config.dart
@@ -53,6 +53,7 @@ class SWPConfig {
     this.useFlutterCompute = false,
     this.generateUrlsConstants = false,
     this.fieldParsers = const [],
+    this.preserveSchemaCasing = false,
   });
 
   /// Internal constructor of [SWPConfig]
@@ -98,6 +99,7 @@ class SWPConfig {
     required this.useFlutterCompute,
     required this.generateUrlsConstants,
     required this.fieldParsers,
+    required this.preserveSchemaCasing,
     this.fallbackUnion,
   });
 
@@ -357,6 +359,9 @@ class SWPConfig {
     final generateUrlsConstants = yamlMap['generate_urls_constants'] as bool? ??
         rootConfig?.generateUrlsConstants;
 
+    final preserveSchemaCasing = yamlMap['preserve_schema_casing'] as bool? ??
+        rootConfig?.preserveSchemaCasing;
+
     final rawFieldParsers = yamlMap['field_parsers'] as YamlList?;
     List<FieldParser>? fieldParsers;
     if (rawFieldParsers != null) {
@@ -432,6 +437,7 @@ class SWPConfig {
       useFlutterCompute: useFlutterCompute ?? dc.useFlutterCompute,
       includePaths: includePathsList ?? dc.includePaths,
       generateUrlsConstants: generateUrlsConstants ?? dc.generateUrlsConstants,
+      preserveSchemaCasing: preserveSchemaCasing ?? dc.preserveSchemaCasing,
     );
   }
 
@@ -674,6 +680,31 @@ class SWPConfig {
   /// {@endtemplate}
   final List<FieldParser> fieldParsers;
 
+  /// Optional. When `true`, schema and enum names are projected into the
+  /// target language by stripping separator characters (spaces, dashes,
+  /// dots, underscores) while preserving the casing of every other
+  /// character. Defaults to `false` — the default behaviour, which
+  /// normalises every name to PascalCase and loses internal acronym and
+  /// lowercase-prefix casing (e.g. `XMLHttpRequest` becomes
+  /// `XmlHttpRequest`).
+  ///
+  /// Examples (flag `true`):
+  /// - `kUserStatus` → `kUserStatus`
+  /// - `XMLHttpRequest` → `XMLHttpRequest`
+  /// - `iOSDevice` → `iOSDevice`
+  /// - `URL` → `URL`
+  /// - `HTTPSConnection` → `HTTPSConnection`
+  /// - `UserStatus` → `UserStatus`
+  /// - `user_status` → `userstatus`
+  /// - `My-Class` → `MyClass`
+  ///
+  /// Useful when the spec author has deliberate casing intent the
+  /// generated code should honour (e.g. `XMLHttpRequest`, a `k`-prefixed
+  /// constant-style enum). `replacement_rules` cannot recover this because
+  /// the normalisation runs first; this flag opts out of the normalisation
+  /// instead.
+  final bool preserveSchemaCasing;
+
   /// Convert [SWPConfig] to [GeneratorConfig]
   GeneratorConfig toGeneratorConfig() {
     return GeneratorConfig(
@@ -731,6 +762,7 @@ class SWPConfig {
       includePaths: includePaths,
       fallbackClient: fallbackClient,
       inferRequiredFromNullable: inferRequiredFromNullable,
+      preserveSchemaCasing: preserveSchemaCasing,
     );
   }
 }

--- a/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart
@@ -19,7 +19,7 @@ String dartDartMappableDtoTemplate(
   // Use fallback union only if explicitly provided
   // Auto-fallback is disabled to avoid breaking existing tests
   final effectiveFallbackUnion = fallbackUnion;
-  final originalClassName = dataClass.name.toPascal;
+  final originalClassName = dataClass.name;
   final discriminator = dataClass.discriminator;
   final isUndiscriminatedUnion =
       dataClass.undiscriminatedUnionVariants?.isNotEmpty ?? false;

--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -22,7 +22,7 @@ String dartEnumDtoTemplate(
       useFlutterCompute: useFlutterCompute,
     );
   } else {
-    final className = enumClass.name.toPascal;
+    final className = enumClass.name;
     final jsonParam = unknownEnumValue || enumsToJson;
     final asyncImport = useFlutterCompute ? "import 'dart:async';\n\n" : '';
 
@@ -63,7 +63,7 @@ String _dartEnumDartMappableTemplate(
   required bool unknownEnumValue,
   required bool useFlutterCompute,
 }) {
-  final className = enumClass.name.toPascal;
+  final className = enumClass.name;
   final jsonParam = unknownEnumValue || enumsToJson;
   final asyncImport = useFlutterCompute ? "import 'dart:async';\n\n" : '';
 

--- a/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
@@ -15,7 +15,7 @@ String dartFreezedDtoTemplate(
   bool useFlutterCompute = false,
   String? fallbackUnion,
 }) {
-  final className = dataClass.name.toPascal;
+  final className = dataClass.name;
   final discriminator = dataClass.discriminator;
   final isUndiscriminatedUnion =
       dataClass.undiscriminatedUnionVariants?.isNotEmpty ?? false;

--- a/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart
@@ -16,7 +16,7 @@ String dartJsonSerializableDtoTemplate(
   bool useFlutterCompute = false,
   String? fallbackUnion,
 }) {
-  final originalClassName = dataClass.name.toPascal;
+  final originalClassName = dataClass.name;
 
   // Check if this is a union type
   final isUnion = dataClass.discriminator != null ||

--- a/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_typedef_template.dart
@@ -8,7 +8,7 @@ import 'package:swagger_parser/src/utils/type_utils.dart';
 /// Provides template for generating dart typedefs using JSON serializable
 String dartTypeDefTemplate(UniversalComponentClass dataClass,
     {required bool useMultipartFile}) {
-  final className = dataClass.name.toPascal;
+  final className = dataClass.name;
   final type = dataClass.parameters.firstOrNull;
   final import = dataClass.imports.firstOrNull;
   if (type == null) {

--- a/swagger_parser/lib/src/generator/templates/kotlin_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_enum_dto_template.dart
@@ -10,7 +10,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-enum class ${dataClass.name.toPascal} {${_parameters(dataClass)}
+enum class ${dataClass.name} {${_parameters(dataClass)}
 }
 ''';
 }

--- a/swagger_parser/lib/src/generator/templates/kotlin_moshi_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_moshi_dto_template.dart
@@ -1,5 +1,4 @@
 import 'package:swagger_parser/src/generator/model/programming_language.dart';
-import 'package:swagger_parser/src/parser/model/normalized_identifier.dart';
 import 'package:swagger_parser/src/parser/swagger_parser_core.dart';
 import 'package:swagger_parser/src/utils/base_utils.dart';
 import 'package:swagger_parser/src/utils/type_utils.dart';
@@ -11,7 +10,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 ${descriptionComment(dataClass.description)}@JsonClass(generateAdapter = true)
-data class ${dataClass.name.toPascal}(${_parameters(dataClass.parameters)}${dataClass.parameters.isNotEmpty ? '\n)' : ')'}
+data class ${dataClass.name}(${_parameters(dataClass.parameters)}${dataClass.parameters.isNotEmpty ? '\n)' : ')'}
 ''';
 }
 

--- a/swagger_parser/lib/src/generator/templates/kotlin_typedef_template.dart
+++ b/swagger_parser/lib/src/generator/templates/kotlin_typedef_template.dart
@@ -1,13 +1,12 @@
 import 'package:collection/collection.dart';
 import 'package:swagger_parser/src/generator/model/programming_language.dart';
-import 'package:swagger_parser/src/parser/model/normalized_identifier.dart';
 import 'package:swagger_parser/src/parser/swagger_parser_core.dart';
 import 'package:swagger_parser/src/utils/base_utils.dart';
 import 'package:swagger_parser/src/utils/type_utils.dart';
 
 /// Provides template for generating dart typedefs using JSON serializable
 String kotlinTypeDefTemplate(UniversalComponentClass dataClass) {
-  final className = dataClass.name.toPascal;
+  final className = dataClass.name;
   final type = dataClass.parameters.firstOrNull;
   if (type == null) {
     return '';

--- a/swagger_parser/lib/src/parser/config/parser_config.dart
+++ b/swagger_parser/lib/src/parser/config/parser_config.dart
@@ -20,6 +20,7 @@ class ParserConfig {
     this.includePaths,
     this.fallbackClient = 'fallback',
     this.inferRequiredFromNullable = false,
+    this.preserveSchemaCasing = false,
   });
 
   /// Specification file content as [String]
@@ -88,4 +89,17 @@ class ParserConfig {
   /// Properties without nullable: true in schema are marked as required.
   /// Only applies when schema has no explicit required array.
   final bool inferRequiredFromNullable;
+
+  /// When `true`, schema and enum names are projected by stripping
+  /// separator characters while preserving the casing of every other
+  /// character.
+  ///
+  /// Examples (flag `true`):
+  /// - `kUserStatus` → `kUserStatus`
+  /// - `XMLHttpRequest` → `XMLHttpRequest`
+  /// - `iOSDevice` → `iOSDevice`
+  /// - `URL` → `URL`
+  /// - `user_status` → `userstatus`
+  /// - `My-Class` → `MyClass`
+  final bool preserveSchemaCasing;
 }

--- a/swagger_parser/lib/src/parser/corrector/open_api_corrector.dart
+++ b/swagger_parser/lib/src/parser/corrector/open_api_corrector.dart
@@ -38,7 +38,9 @@ class OpenApiCorrector {
         for (final rule in config.replacementRules) {
           correctType = rule.apply(correctType)!;
         }
-        correctType = correctType.toPascal;
+        correctType = config.preserveSchemaCasing
+            ? correctType.toPreservedCase
+            : correctType.toPascal;
         if (correctType != type) {
           typeCorrections[type] = correctType;
         }

--- a/swagger_parser/lib/src/parser/model/normalized_identifier.dart
+++ b/swagger_parser/lib/src/parser/model/normalized_identifier.dart
@@ -240,6 +240,33 @@ extension StringToCaseX on String {
         : identifier.pascalCase;
   }
 
+  /// Strip separator characters (spaces, dashes, dots, underscores, etc.)
+  /// while preserving the casing of every other character.
+  ///
+  /// - `XMLHttpRequest` → `XMLHttpRequest`
+  /// - `kUserStatus` → `kUserStatus`
+  /// - `iOSDevice` → `iOSDevice`
+  /// - `URL` → `URL`
+  /// - `user_status` → `userstatus`
+  /// - `My-Class` → `MyClass`
+  /// - `XML Http Request` → `XMLHttpRequest`
+  ///
+  /// Mirrors [toPascal]'s `Private` prefix handling for inputs starting
+  /// with a single underscore.
+  ///
+  /// Used by the `preserve_schema_casing` config option to project
+  /// spec-author identifiers into the target language verbatim where
+  /// possible.
+  String get toPreservedCase {
+    if (isEmpty) {
+      return '';
+    }
+    final isPrivate = startsWith('_');
+    final body = isPrivate ? substring(1) : this;
+    final stripped = body.replaceAll(_separatorPattern, '');
+    return isPrivate ? 'Private$stripped' : stripped;
+  }
+
   /// Return text formatted to snake_case
   ///
   /// The result is prefixed with `private_` if the given text indicates a private entity

--- a/swagger_parser/lib/src/parser/model/normalized_identifier.dart
+++ b/swagger_parser/lib/src/parser/model/normalized_identifier.dart
@@ -251,8 +251,8 @@ extension StringToCaseX on String {
   /// - `My-Class` → `MyClass`
   /// - `XML Http Request` → `XMLHttpRequest`
   ///
-  /// Mirrors [toPascal]'s `Private` prefix handling for inputs starting
-  /// with a single underscore.
+  /// Mirrors [toPascal]'s `Private` prefix handling for inputs that start
+  /// with an underscore.
   ///
   /// Used by the `preserve_schema_casing` config option to project
   /// spec-author identifiers into the target language verbatim where

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -32,6 +32,12 @@ class OpenApiParser {
   /// [ParserConfig] that [OpenApiParser] use
   final ParserConfig config;
 
+  /// Normalises a schema-derived identifier — preserves the spec author's
+  /// casing (stripping separators only) when [ParserConfig.preserveSchemaCasing]
+  /// is on, otherwise falls back to PascalCase.
+  String _schemaIdentifier(String input) =>
+      config.preserveSchemaCasing ? input.toPreservedCase : input.toPascal;
+
   /// `info` section in specification
   late final OpenApiInfo _apiInfo;
 
@@ -129,7 +135,7 @@ class OpenApiParser {
 
     return UniversalEnumClass(
       originalName: name,
-      name: uniqueName.toPascal,
+      name: _schemaIdentifier(uniqueName),
       type: type,
       items: items,
       defaultValue: defaultValue,
@@ -1533,7 +1539,7 @@ class OpenApiParser {
 
       final (parameters, imports) = _findParametersAndImports(map);
 
-      var type = newName.toPascal;
+      var type = _schemaIdentifier(newName);
 
       for (final replacementRule in config.replacementRules) {
         type = replacementRule.apply(type)!;
@@ -1991,15 +1997,15 @@ class OpenApiParser {
       String? import;
       String type;
       if (map.containsKey(_refConst)) {
-        import = _formatRef(map).toPascal;
+        import = _schemaIdentifier(_formatRef(map));
       } else if (map.containsKey(_additionalPropertiesConst) &&
           map[_additionalPropertiesConst] is Map<String, dynamic> &&
           (map[_additionalPropertiesConst] as Map<String, dynamic>).containsKey(
             _refConst,
           )) {
-        import = _formatRef(
+        import = _schemaIdentifier(_formatRef(
           map[_additionalPropertiesConst] as Map<String, dynamic>,
-        ).toPascal;
+        ));
       }
 
       if (map.containsKey(_typeConst)) {
@@ -2010,7 +2016,7 @@ class OpenApiParser {
         type = import ?? _objectConst;
       }
       if (import != null) {
-        type = type.toPascal;
+        type = _schemaIdentifier(type);
       }
 
       final defaultValue = map[_defaultConst]?.toString();
@@ -2178,7 +2184,7 @@ class OpenApiParser {
 
     for (final item in otherItems) {
       if (item.containsKey(_refConst)) {
-        final refName = _formatRef(item).toPascal;
+        final refName = _schemaIdentifier(_formatRef(item));
 
         // Locate the referenced component to get its properties if available.
         if (_definitionFileContent

--- a/swagger_parser/pubspec.yaml
+++ b/swagger_parser/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_parser
 description: Package that generates REST clients and data classes from OpenApi definition file
-version: 1.43.1
+version: 1.44.0
 repository: https://github.com/Carapacik/swagger_parser
 topics:
   - swagger

--- a/swagger_parser/test/config/swp_config_test.dart
+++ b/swagger_parser/test/config/swp_config_test.dart
@@ -41,6 +41,7 @@ void main() {
         expect(config.includeTags, isEmpty);
         expect(config.fallbackClient, 'fallback');
         expect(config.includeIfNull, isFalse);
+        expect(config.preserveSchemaCasing, isFalse);
       });
 
       test('should create config with all parameters specified', () {
@@ -82,6 +83,7 @@ void main() {
           includeTags: ['public', 'stable'],
           fallbackClient: 'common',
           includeIfNull: true,
+          preserveSchemaCasing: true,
         );
 
         expect(config.outputDirectory, equals('lib/generated'));
@@ -118,6 +120,7 @@ void main() {
         expect(config.includeTags, equals(['public', 'stable']));
         expect(config.fallbackClient, equals('common'));
         expect(config.includeIfNull, isTrue);
+        expect(config.preserveSchemaCasing, isTrue);
       });
     });
 
@@ -169,6 +172,7 @@ void main() {
             'exclude_tags': ['internal', 'deprecated'],
             'include_tags': ['public', 'stable'],
             'include_if_null': true,
+            'preserve_schema_casing': true,
             'replacement_rules': [
               {'pattern': 'Test', 'replacement': 'Mock'},
               {'pattern': 'Dto', 'replacement': 'Model'},
@@ -209,6 +213,7 @@ void main() {
           expect(config.excludeTags, equals(['internal', 'deprecated']));
           expect(config.includeTags, equals(['public', 'stable']));
           expect(config.includeIfNull, isTrue);
+          expect(config.preserveSchemaCasing, isTrue);
           expect(config.replacementRules, hasLength(2));
           expect(config.replacementRules[0].pattern.pattern, equals('Test'));
           expect(config.replacementRules[0].replacement, equals('Mock'));
@@ -764,6 +769,79 @@ void main() {
       // The exact behavior depends on ProgrammingLanguage.fromString implementation
       expect(() => SWPConfig.fromYaml(yamlMap),
           isNot(throwsA(isA<ConfigException>())));
+    });
+  });
+
+  group('Preserve Schema Casing Configuration', () {
+    test('should default preserveSchemaCasing to false', () {
+      const config = SWPConfig(outputDirectory: 'lib/api');
+      expect(config.preserveSchemaCasing, isFalse);
+    });
+
+    test('should parse preserveSchemaCasing from YAML when set to true', () {
+      final yamlMap = YamlMap.wrap({
+        'schema_path': 'api/openapi.yaml',
+        'output_directory': 'lib/api',
+        'preserve_schema_casing': true,
+      });
+
+      final config = SWPConfig.fromYaml(yamlMap);
+      expect(config.preserveSchemaCasing, isTrue);
+    });
+
+    test('should parse preserveSchemaCasing from YAML when set to false', () {
+      final yamlMap = YamlMap.wrap({
+        'schema_path': 'api/openapi.yaml',
+        'output_directory': 'lib/api',
+        'preserve_schema_casing': false,
+      });
+
+      final config = SWPConfig.fromYaml(yamlMap);
+      expect(config.preserveSchemaCasing, isFalse);
+    });
+
+    test('should inherit preserveSchemaCasing from root config', () {
+      const rootConfig = SWPConfig(
+        outputDirectory: 'lib/shared',
+        preserveSchemaCasing: true,
+      );
+
+      final yamlMap = YamlMap.wrap({
+        'schema_path': 'api/user.yaml',
+        'name': 'user_api',
+      });
+
+      final config = SWPConfig.fromYaml(yamlMap, rootConfig: rootConfig);
+      expect(config.preserveSchemaCasing, isTrue);
+    });
+
+    test('should override root config preserveSchemaCasing with local value',
+        () {
+      const rootConfig = SWPConfig(
+        outputDirectory: 'lib/shared',
+        preserveSchemaCasing: true,
+      );
+
+      final yamlMap = YamlMap.wrap({
+        'schema_path': 'api/user.yaml',
+        'preserve_schema_casing': false,
+      });
+
+      final config = SWPConfig.fromYaml(yamlMap, rootConfig: rootConfig);
+      expect(config.preserveSchemaCasing, isFalse);
+    });
+
+    test('should pass preserveSchemaCasing to ParserConfig', () {
+      const swpConfig = SWPConfig(
+        outputDirectory: 'lib/api',
+        preserveSchemaCasing: true,
+      );
+
+      final parserConfig = swpConfig.toParserConfig(
+        fileContent: '{}',
+        isJson: true,
+      );
+      expect(parserConfig.preserveSchemaCasing, isTrue);
     });
   });
 

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -19,6 +19,20 @@ void main() {
       );
     });
 
+    test('preserve_schema_casing', () async {
+      await e2eTest(
+        'preserve_schema_casing',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          preserveSchemaCasing: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
     test('generate_urls_constants', () async {
       await e2eTest(
         'generate_urls_constants',

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/clients/fallback_client.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/clients/fallback_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/user.dart';
+
+part 'fallback_client.g.dart';
+
+@RestApi()
+abstract class FallbackClient {
+  factory FallbackClient(Dio dio, {String? baseUrl}) = _FallbackClient;
+
+  @GET('/me')
+  Future<User> getMe();
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/export.dart
@@ -1,0 +1,14 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/fallback_client.dart';
+// Data classes
+export 'models/k_user_status.dart';
+export 'models/url.dart';
+export 'models/xml_http_request.dart';
+export 'models/i_os_device.dart';
+export 'models/user.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/i_os_device.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/i_os_device.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'i_os_device.freezed.dart';
+part 'i_os_device.g.dart';
+
+@Freezed()
+class iOSDevice with _$iOSDevice {
+  const factory iOSDevice({
+    required String deviceId,
+  }) = _iOSDevice;
+
+  factory iOSDevice.fromJson(Map<String, Object?> json) =>
+      _$iOSDeviceFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/k_user_status.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/k_user_status.dart
@@ -1,0 +1,32 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum kUserStatus {
+  @JsonValue('PENDING')
+  pending('PENDING'),
+  @JsonValue('ACTIVE')
+  active('ACTIVE'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const kUserStatus(this.json);
+
+  factory kUserStatus.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<kUserStatus> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/url.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/url.dart
@@ -1,0 +1,5 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+typedef URL = String;

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/user.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/user.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'url.dart';
+import 'xml_http_request.dart';
+import 'i_os_device.dart';
+import 'k_user_status.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+@Freezed()
+class User with _$User {
+  const factory User({
+    required String userId,
+    required kUserStatus status,
+    required iOSDevice device,
+    required URL homepage,
+    required XMLHttpRequest lastRequest,
+  }) = _User;
+
+  factory User.fromJson(Map<String, Object?> json) => _$UserFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/xml_http_request.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/models/xml_http_request.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'url.dart';
+
+part 'xml_http_request.freezed.dart';
+part 'xml_http_request.g.dart';
+
+@Freezed()
+class XMLHttpRequest with _$XMLHttpRequest {
+  const factory XMLHttpRequest({
+    required URL url,
+  }) = _XMLHttpRequest;
+
+  factory XMLHttpRequest.fromJson(Map<String, Object?> json) =>
+      _$XMLHttpRequestFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/expected_files/rest_client.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/fallback_client.dart';
+
+/// Test API for preserve_schema_casing `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  FallbackClient? _fallback;
+
+  FallbackClient get fallback =>
+      _fallback ??= FallbackClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/preserve_schema_casing/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/preserve_schema_casing/openapi.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.0
+info:
+  title: Test API for preserve_schema_casing
+  version: 1.0.0
+paths:
+  /me:
+    get:
+      operationId: getMe
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    # camelCase prefix should be preserved.
+    kUserStatus:
+      type: string
+      enum:
+        - PENDING
+        - ACTIVE
+    # All-uppercase acronym should be preserved.
+    URL:
+      type: string
+    # Acronym in the middle of a PascalCase name should be preserved
+    # (currently swagger_parser would emit XmlHttpRequest).
+    XMLHttpRequest:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          $ref: "#/components/schemas/URL"
+    # Lowercase prefix that wraps a PascalCase suffix should round-trip
+    # (currently swagger_parser would emit IOSDevice).
+    iOSDevice:
+      type: object
+      required:
+        - deviceId
+      properties:
+        deviceId:
+          type: string
+    User:
+      type: object
+      required:
+        - userId
+        - status
+        - device
+        - homepage
+        - lastRequest
+      properties:
+        userId:
+          type: string
+        status:
+          $ref: "#/components/schemas/kUserStatus"
+        device:
+          $ref: "#/components/schemas/iOSDevice"
+        homepage:
+          $ref: "#/components/schemas/URL"
+        lastRequest:
+          $ref: "#/components/schemas/XMLHttpRequest"

--- a/swagger_parser/test/src/parser/model/normalized_identifier_test.dart
+++ b/swagger_parser/test/src/parser/model/normalized_identifier_test.dart
@@ -1060,5 +1060,54 @@ void main() {
         expect(identifier.words, edgeCase.expectedWords);
       });
     }
+
+    group('String.toPreservedCase', () {
+      test('preserves no-separator identifiers verbatim', () {
+        expect('UserStatus'.toPreservedCase, 'UserStatus');
+        expect('User'.toPreservedCase, 'User');
+        expect('kUserStatus'.toPreservedCase, 'kUserStatus');
+        expect('XMLHttpRequest'.toPreservedCase, 'XMLHttpRequest');
+        expect('iOSDevice'.toPreservedCase, 'iOSDevice');
+        expect('URL'.toPreservedCase, 'URL');
+        expect('HTTPSConnection'.toPreservedCase, 'HTTPSConnection');
+      });
+
+      test('strips separators while keeping the casing of letters/digits', () {
+        expect('user_status'.toPreservedCase, 'userstatus');
+        expect('My-Class'.toPreservedCase, 'MyClass');
+        expect('XML Http Request'.toPreservedCase, 'XMLHttpRequest');
+        expect('com.example.Api'.toPreservedCase, 'comexampleApi');
+      });
+
+      test('mirrors toPascal Private-prefix handling', () {
+        expect('_kUserStatus'.toPreservedCase, 'PrivatekUserStatus');
+        expect('_XMLHttpRequest'.toPreservedCase, 'PrivateXMLHttpRequest');
+        expect('_UserStatus'.toPreservedCase, 'PrivateUserStatus');
+      });
+
+      test('strips inner underscores even after a private prefix', () {
+        // The leading underscore is consumed as the private marker; any
+        // remaining underscores are stripped along with other separators.
+        expect('_user_status'.toPreservedCase, 'Privateuserstatus');
+      });
+
+      test('is idempotent on its own output', () {
+        for (final input in [
+          'XMLHttpRequest',
+          'kUserStatus',
+          'UserStatus',
+          'iOSDevice',
+          'URL',
+        ]) {
+          final once = input.toPreservedCase;
+          expect(once.toPreservedCase, once,
+              reason: 'not idempotent for $input');
+        }
+      });
+
+      test('returns empty for empty input', () {
+        expect(''.toPreservedCase, '');
+      });
+    });
   });
 }


### PR DESCRIPTION
# Add `preserve_schema_casing` option to honour spec-author casing

Fixes #458 

## Summary

Adds an opt-in config flag `preserve_schema_casing` (default `false`) that
projects schema and enum names into the target language by stripping
separator characters while preserving the casing of every other character.
This lets generators emit `XMLHttpRequest`, `kUserStatus`, `iOSDevice`, and
`URL` verbatim instead of normalising them to `XmlHttpRequest`,
`KUserStatus`, `IOsDevice`, and `Url`.

Currently the only way around the normalisation is `replacement_rules`,
which doesn't work for this case because the rules run *after* the
PascalCase normalisation has already destroyed the casing information.

## Behaviour

When `preserve_schema_casing: true`:

| Schema name | Output | Note |
|---|---|---|
| `kUserStatus` | `kUserStatus` | lowercase prefix preserved |
| `XMLHttpRequest` | `XMLHttpRequest` | internal acronym preserved |
| `iOSDevice` | `iOSDevice` | mixed-case prefix preserved |
| `URL` | `URL` | all-caps preserved |
| `HTTPSConnection` | `HTTPSConnection` | |
| `UserStatus` | `UserStatus` | unchanged |
| `user_status` | `userstatus` | separator stripped, rest verbatim |
| `My-Class` | `MyClass` | separator stripped |
| `XML Http Request` | `XMLHttpRequest` | spaces stripped, casing kept |

The rule is uniform: **strip separator characters, preserve the casing of
every other character**. No special-casing, no carve-outs.

Default (`false`) is the existing PascalCase normalisation — unchanged.

## Implementation

The change adds one new String extension and threads a single decision
point through the existing flow:

- **`String.toPreservedCase`** (new): one small extension getter in
  `lib/src/parser/model/normalized_identifier.dart` that strips separator
  characters and mirrors `toPascal`'s `Private` prefix handling. Uses the
  same `_separatorPattern` already defined at the top of the file.

- **`OpenApiCorrector`**: a one-line conditional swaps `correctType.toPascal`
  for `correctType.toPreservedCase` when the flag is on. This is where
  schema keys get rewritten in the JSON/YAML content before the parser
  reads it.

- **`OpenApiParser`**: a small private helper
  `String _schemaIdentifier(String input)` picks between `.toPreservedCase`
  and `.toPascal` based on the flag. Wired into 6 call sites that handle
  user-controlled schema names (enum class name, inline schema type, `$ref`
  resolutions). The corrector's YAML rewrite is skipped when the preserved
  form equals the input, so the parser still has to honour the flag for
  those cases. Synthesised wrapper names (`'X Union'.toPascal`,
  `'$name $additionalName'.toPascal`) are intentionally left
  unconditional — they should always be PascalCase.

- **Config wiring**: `SWPConfig.preserveSchemaCasing` field + YAML key
  `preserve_schema_casing` + `toParserConfig` plumbing +
  `ParserConfig.preserveSchemaCasing`.

`NormalizedIdentifier` itself is untouched — no new fields, no new
getters on the class. The only addition is one String extension at the
bottom of the same file.

## Why the DTO templates changed (and why it doesn't actually matter)

Five templates had `final className = dataClass.name.toPascal;`. With the
flag on, that would convert `XMLHttpRequest` back to `XmlHttpRequest` and
defeat the preservation. The fix changes them to
`final className = dataClass.name;` — dropping the call entirely.

This works because the parser already stores `name` in its final
target-language form for both modes:

- Component class names are assigned from post-corrector keys (PascalCase
  in legacy mode, preserved-case in flag-on mode).
- Enum class names go through `_schemaIdentifier(uniqueName)`.
- Synthesised wrapper names are pascalised at construction.

In other words: `dataClass.name` is already a final identifier by the
time it reaches a template, so `.toPascal` was always redundant. The
codebase already implicitly assumes this — see
[dart_json_serializable_dto_template.dart:515](https://github.com/...) and
[dart_dart_mappable_dto_template.dart:652](https://github.com/...), which
compare `variantName == dataClass.name` without any transformation.

Removing the redundant `.toPascal` from the templates is a no-op in
legacy mode (PascalCase in → PascalCase out) and necessary in flag-on
mode (preserved-case in → preserved-case out).

`UniversalComponentClass.import` is **not** touched. It still returns
`name.toPascal`, exactly as upstream. The only consumer adds the result
to an `imports` set that downstream templates snake-case via `.toSnake`
for filename derivation — and `.toSnake('XMLHttpRequest')` ==
`.toSnake('XmlHttpRequest')`, so the existing `.toPascal` is harmless
even in flag-on mode.

## Tests

No existing tests were modified — none of the changes affect behaviour
when the flag is off, and all 421 pre-existing tests pass unchanged.

New tests added:

- **`test/src/parser/model/normalized_identifier_test.dart`** — a new
  `String.toPreservedCase` group covering: no-separator preservation,
  separator stripping, `Private` prefix handling, inner-underscore
  stripping after a private prefix, idempotency, and empty input.
- **`test/config/swp_config_test.dart`** — a new `Preserve Schema
  Casing Configuration` group following the same shape as the existing
  `Include If Null Configuration` group (default value, YAML parsing
  true/false, root config inheritance, override, `toParserConfig`
  wiring). Plus three assertions added to the existing
  constructor/YAML-loading tests to cover the new field.
- **`test/e2e/tests/preserve_schema_casing/`** — a new e2e fixture
  whose OpenAPI spec exercises `kUserStatus`, `XMLHttpRequest`,
  `iOSDevice`, and `URL` as top-level schemas, all referenced as fields
  of a `User` model. The expected generated files prove that the class
  names, type references, and (snake_case) filenames all line up.
- **`test/e2e/e2e_test.dart`** — one new test entry registering the
  fixture above.

Total suite: 422 passing.

## Files touched

```
 swagger_parser/lib/src/config/swp_config.dart                          | +32
 swagger_parser/lib/src/generator/templates/dart_dart_mappable_dto_template.dart | ±1
 swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart          | ±2
 swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart       | ±1
 swagger_parser/lib/src/generator/templates/dart_json_serializable_dto_template.dart | ±1
 swagger_parser/lib/src/generator/templates/dart_typedef_template.dart           | ±1
 swagger_parser/lib/src/parser/config/parser_config.dart                | +14
 swagger_parser/lib/src/parser/corrector/open_api_corrector.dart        | ±4
 swagger_parser/lib/src/parser/model/normalized_identifier.dart         | +27
 swagger_parser/lib/src/parser/parser/open_api_parser.dart              | ±20
 swagger_parser/test/config/swp_config_test.dart                        | +78
 swagger_parser/test/e2e/e2e_test.dart                                  | +14
 swagger_parser/test/src/parser/model/normalized_identifier_test.dart   | +49
 swagger_parser/test/e2e/tests/preserve_schema_casing/                  | new fixture
```

`dart format .` clean. `dart analyze` reports no issues. `dart test`
passes 422/422.
