### PR TITLE
fix: keep nested union imports in freezed discriminated-union variants

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -3,7 +3,6 @@
 - Add `preserve_schema_casing` option to preserve original casing of schema-derived identifiers, defaults to `false` for backwards compatibility, which normalises to PascalCase
 - Fix crash when a `multipart/form-data` request body references a schema without `properties`
 
-
 ## 1.43.1
 - Fix escaping `$unknown` in generated enum `toJson` error messages
 - Fix generated code when using `json_serializable`

--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.44.0
 
 - Add `preserve_schema_casing` option to preserve original casing of schema-derived identifiers, defaults to `false` for backwards compatibility, which normalises to PascalCase
+- Fix freezed discriminated-union variants dropping the import for their own nested `oneOf` properties, producing references to undefined union types
 
 ## 1.43.1
 - Fix escaping `$unknown` in generated enum `toJson` error messages

--- a/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_freezed_dto_template.dart
@@ -390,21 +390,38 @@ FutureOr<List<Map<String, dynamic>>> serialize${className}List(List<$className>?
 ''';
 }
 
-/// Filters out union imports for freezed classes to avoid circular dependencies
+/// Filters out the parent-union back-import for freezed union variants.
+///
+/// A discriminated-union *variant* (`discriminatorValue != null`) is inlined
+/// into its parent union file, so the parent union gets injected into this
+/// class's `imports` even though the variant never references that type. That
+/// back-import must be dropped (it is a dependency cycle and is unused).
+///
+/// However, a variant may have its own `oneOf`-typed properties whose generated
+/// union files it genuinely references and MUST import — otherwise the property
+/// types are undefined and the file fails to compile. We tell the two apart by
+/// keeping only the union imports that correspond to a type actually used by
+/// one of this class's properties.
 Set<String> _filterUnionImportsForFreezed(UniversalComponentClass dataClass) {
+  // Only variants risk the parent-union back-import; every other class keeps
+  // all of its imports untouched.
+  if (dataClass.discriminatorValue == null) {
+    return dataClass.imports;
+  }
+
+  final referencedTypes = <String>{
+    for (final p in dataClass.parameters) p.type,
+    ...?dataClass.allOf?.properties.map((p) => p.type),
+  };
+
   final filteredImports = <String>{};
 
-  // If this class has a discriminatorValue, it means it's part of a union and
-  // shouldn't import the union file (to avoid circular dependencies)
-  final shouldFilterUnionImports = dataClass.discriminatorValue != null;
-
   for (final import in dataClass.imports) {
-    // If this is a model that's part of a union, skip union imports
-    // Otherwise, allow all imports (including union imports for classes that use unions)
-    final shouldSkip =
-        shouldFilterUnionImports && import.toLowerCase().contains('union');
-
-    if (!shouldSkip) {
+    final isUnionImport = import.toLowerCase().contains('union');
+    // Keep non-union imports, and union imports that this class references
+    // through its own properties (its inline `oneOf` fields). Drop the rest
+    // (the parent union this variant belongs to).
+    if (!isUnionImport || referencedTypes.contains(import)) {
       filteredImports.add(import);
     }
   }

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -953,6 +953,20 @@ void main() {
       );
     });
 
+    test('freezed_nested_union_variant_imports', () async {
+      await e2eTest(
+        'xof/freezed_nested_union_variant_imports',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          useFreezed3: true,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'freezed_nested_union_variant_imports.3.1.yaml',
+      );
+    });
+
     test('discriminated_any_of_complete_mapping_mappable', () async {
       await e2eTest(
         'xof/discriminated_any_of_complete_mapping_mappable',

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/clients/pets_client.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/clients/pets_client.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/get_pets_response_union.dart';
+
+part 'pets_client.g.dart';
+
+@RestApi()
+abstract class PetsClient {
+  factory PetsClient(Dio dio, {String? baseUrl}) = _PetsClient;
+
+  /// List pets (discriminated union); the Cat variant nests its own union.
+  @GET('/pets')
+  Future<List<GetPetsResponseUnion>> getPets();
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/export.dart
@@ -1,0 +1,19 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/pets_client.dart';
+// Data classes
+export 'models/cat.dart';
+export 'models/dog.dart';
+export 'models/ball.dart';
+export 'models/mouse.dart';
+export 'models/get_pets_response_union.dart';
+export 'models/cat_toy_union.dart';
+export 'models/cat_type.dart';
+export 'models/dog_type.dart';
+export 'models/ball_kind.dart';
+export 'models/mouse_kind.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/ball.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/ball.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'ball_kind.dart';
+
+part 'ball.freezed.dart';
+part 'ball.g.dart';
+
+@Freezed()
+abstract class Ball with _$Ball {
+  const factory Ball({
+    required BallKind kind,
+    required int diameterCm,
+  }) = _Ball;
+
+  factory Ball.fromJson(Map<String, Object?> json) => _$BallFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/ball_kind.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/ball_kind.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum BallKind {
+  @JsonValue('Ball')
+  ball('Ball'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const BallKind(this.json);
+
+  factory BallKind.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<BallKind> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat.dart
@@ -1,0 +1,22 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'cat_toy_union.dart';
+import 'cat_type.dart';
+
+part 'cat.freezed.dart';
+part 'cat.g.dart';
+
+/// A union variant that itself contains a nested discriminated union.
+@Freezed()
+abstract class Cat with _$Cat {
+  const factory Cat({
+    required CatType type,
+    required CatToyUnion toy,
+  }) = _Cat;
+
+  factory Cat.fromJson(Map<String, Object?> json) => _$CatFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat_toy_union.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat_toy_union.dart
@@ -1,0 +1,31 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'ball.dart';
+import 'ball_kind.dart';
+import 'mouse.dart';
+import 'mouse_kind.dart';
+
+part 'cat_toy_union.freezed.dart';
+part 'cat_toy_union.g.dart';
+
+@Freezed(unionKey: 'kind')
+sealed class CatToyUnion with _$CatToyUnion {
+  @FreezedUnionValue('Ball')
+  const factory CatToyUnion.ball({
+    required BallKind kind,
+    required int diameterCm,
+  }) = CatToyUnionBall;
+
+  @FreezedUnionValue('Mouse')
+  const factory CatToyUnion.mouse({
+    required MouseKind kind,
+    required bool squeaky,
+  }) = CatToyUnionMouse;
+
+  factory CatToyUnion.fromJson(Map<String, Object?> json) =>
+      _$CatToyUnionFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/cat_type.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum CatType {
+  @JsonValue('Cat')
+  cat('Cat'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const CatType(this.json);
+
+  factory CatType.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<CatType> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/dog.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/dog.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'dog_type.dart';
+
+part 'dog.freezed.dart';
+part 'dog.g.dart';
+
+@Freezed()
+abstract class Dog with _$Dog {
+  const factory Dog({
+    required DogType type,
+    required String barkSound,
+  }) = _Dog;
+
+  factory Dog.fromJson(Map<String, Object?> json) => _$DogFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/dog_type.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/dog_type.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum DogType {
+  @JsonValue('Dog')
+  dog('Dog'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const DogType(this.json);
+
+  factory DogType.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<DogType> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/get_pets_response_union.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/get_pets_response_union.dart
@@ -1,0 +1,32 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'cat.dart';
+import 'cat_toy_union.dart';
+import 'cat_type.dart';
+import 'dog.dart';
+import 'dog_type.dart';
+
+part 'get_pets_response_union.freezed.dart';
+part 'get_pets_response_union.g.dart';
+
+@Freezed(unionKey: 'type')
+sealed class GetPetsResponseUnion with _$GetPetsResponseUnion {
+  @FreezedUnionValue('Cat')
+  const factory GetPetsResponseUnion.cat({
+    required CatType type,
+    required CatToyUnion toy,
+  }) = GetPetsResponseUnionCat;
+
+  @FreezedUnionValue('Dog')
+  const factory GetPetsResponseUnion.dog({
+    required DogType type,
+    required String barkSound,
+  }) = GetPetsResponseUnionDog;
+
+  factory GetPetsResponseUnion.fromJson(Map<String, Object?> json) =>
+      _$GetPetsResponseUnionFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/mouse.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/mouse.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'mouse_kind.dart';
+
+part 'mouse.freezed.dart';
+part 'mouse.g.dart';
+
+@Freezed()
+abstract class Mouse with _$Mouse {
+  const factory Mouse({
+    required MouseKind kind,
+    required bool squeaky,
+  }) = _Mouse;
+
+  factory Mouse.fromJson(Map<String, Object?> json) => _$MouseFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/mouse_kind.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/models/mouse_kind.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@JsonEnum()
+enum MouseKind {
+  @JsonValue('Mouse')
+  mouse('Mouse'),
+
+  /// Default value for all unparsed values, allows backward compatibility when adding new values on the backend.
+  $unknown(null);
+
+  const MouseKind(this.json);
+
+  factory MouseKind.fromJson(String json) => values.firstWhere(
+        (e) => e.json == json,
+        orElse: () => $unknown,
+      );
+
+  final String? json;
+
+  @override
+  String toString() => json?.toString() ?? super.toString();
+
+  /// Returns all defined enum values excluding the $unknown value.
+  static List<MouseKind> get $valuesDefined =>
+      values.where((value) => value != $unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/pets_client.dart';
+
+/// Nested Union Variant Imports API `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  PetsClient? _pets;
+
+  PetsClient get pets => _pets ??= PetsClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/freezed_nested_union_variant_imports.3.1.yaml
+++ b/swagger_parser/test/e2e/tests/xof/freezed_nested_union_variant_imports/freezed_nested_union_variant_imports.3.1.yaml
@@ -1,0 +1,72 @@
+openapi: 3.1.0
+info:
+  title: Nested Union Variant Imports API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: getPets
+      summary: List pets (discriminated union); the Cat variant nests its own union.
+      tags: [pets]
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      Cat: '#/components/schemas/Cat'
+                      Dog: '#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      description: A union variant that itself contains a nested discriminated union.
+      properties:
+        type:
+          type: string
+          enum: [Cat]
+        toy:
+          oneOf:
+            - $ref: '#/components/schemas/Ball'
+            - $ref: '#/components/schemas/Mouse'
+          discriminator:
+            propertyName: kind
+            mapping:
+              Ball: '#/components/schemas/Ball'
+              Mouse: '#/components/schemas/Mouse'
+      required: [type, toy]
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [Dog]
+        barkSound:
+          type: string
+      required: [type, barkSound]
+    Ball:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [Ball]
+        diameterCm:
+          type: integer
+      required: [kind, diameterCm]
+    Mouse:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [Mouse]
+        squeaky:
+          type: boolean
+      required: [kind, squeaky]


### PR DESCRIPTION
## Problem

With `json_serializer: freezed`, a DTO that is a discriminated-union *variant* and also contains its own nested `oneOf` property generates a file that references the nested union type without importing it, so the generated code does not compile (undefined `*Union` type).

A non-variant DTO with the same nested union compiles fine — the bug only affects variants.

## Root cause

`_filterUnionImportsForFreezed` in `dart_freezed_dto_template.dart` drops every import whose name contains `"union"` when `discriminatorValue != null`. The intent is to drop the parent-union back-import (the variant is inlined into the parent union file). But the blunt match also drops the union files generated for the variant's *own* nested `oneOf` properties, which are genuinely referenced.

## Fix

Only drop union imports the variant does not reference through its own properties; keep the union files for its inline `oneOf` fields.

## Tests

Adds an e2e regression test `xof/freezed_nested_union_variant_imports` (a discriminated union whose `Cat` variant carries a nested discriminated union `toy`). Full suite passes; `dart format` and `dart analyze` clean.
