### PR TITLE
fix: honor sibling nullable:true on single-element allOf/oneOf/anyOf

### DIFF
--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -1709,6 +1709,15 @@ class OpenApiParser {
               name: name,
               additionalName: additionalName,
             );
+            // OpenAPI 3.0 expresses a nullable composed type with a sibling
+            // `nullable: true` next to a single-element allOf/oneOf/anyOf, e.g.
+            // {nullable: true, allOf: [{$ref: ...}]}. The inner item itself is
+            // not nullable, so honor the outer flag here (the 3.1 form,
+            // {oneOf: [{$ref}, {type: null}]}, is handled by the multi-element
+            // branch below via nullItems).
+            if (map[_nullableConst].toString().toBool() ?? false) {
+              ofType = makeNullable(ofType);
+            }
           }
         }
         // Find n-element anyOf/allOf/oneOf (without discriminator) or type: [type, "null"]

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -868,6 +868,20 @@ void main() {
       );
     });
 
+    test('nullable_sibling_all_of.3.0', () async {
+      await e2eTest(
+        'xof/nullable_sibling_all_of.3.0',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          useFreezed3: true,
+          putClientsInFolder: true,
+        ),
+        schemaFileName: 'nullable_sibling_all_of.3.0.json',
+      );
+    });
+
     test('discriminated_one_of.3.0', () async {
       await e2eTest(
         'xof/discriminated_one_of.3.0',

--- a/swagger_parser/test/e2e/tests/xof/all_of.3.0/expected_files/clients/users_client.dart
+++ b/swagger_parser/test/e2e/tests/xof/all_of.3.0/expected_files/clients/users_client.dart
@@ -32,7 +32,7 @@ abstract class UsersClient {
   ///
   /// [id] - The id of the user.
   @GET('/users/{id}')
-  Future<UserDto> getUserById({
+  Future<UserDto?> getUserById({
     @Path('id') required String id,
   });
 }

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/clients/fallback_client.dart
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/clients/fallback_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/composition_dto.dart';
+
+part 'fallback_client.g.dart';
+
+@RestApi()
+abstract class FallbackClient {
+  factory FallbackClient(Dio dio, {String? baseUrl}) = _FallbackClient;
+
+  @GET('/composition')
+  Future<CompositionDto> getComposition();
+}

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/export.dart
@@ -1,0 +1,11 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/fallback_client.dart';
+// Data classes
+export 'models/item_dto.dart';
+export 'models/composition_dto.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/models/composition_dto.dart
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/models/composition_dto.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'item_dto.dart';
+
+part 'composition_dto.freezed.dart';
+part 'composition_dto.g.dart';
+
+@Freezed()
+abstract class CompositionDto with _$CompositionDto {
+  const factory CompositionDto({
+    /// OpenAPI 3.0 style: sibling nullable:true next to a single-element allOf
+    required ItemDto? nullableAllOf,
+
+    /// OpenAPI 3.1 style: oneOf with an explicit null branch (already supported)
+    required ItemDto? nullableOneOf,
+  }) = _CompositionDto;
+
+  factory CompositionDto.fromJson(Map<String, Object?> json) =>
+      _$CompositionDtoFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/models/item_dto.dart
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/models/item_dto.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item_dto.freezed.dart';
+part 'item_dto.g.dart';
+
+@Freezed()
+abstract class ItemDto with _$ItemDto {
+  const factory ItemDto({
+    required String id,
+  }) = _ItemDto;
+
+  factory ItemDto.fromJson(Map<String, Object?> json) =>
+      _$ItemDtoFromJson(json);
+}

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/expected_files/rest_client.dart
@@ -1,0 +1,28 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/fallback_client.dart';
+
+/// API `v1.0`.
+///
+/// API description.
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0';
+
+  FallbackClient? _fallback;
+
+  FallbackClient get fallback =>
+      _fallback ??= FallbackClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/nullable_sibling_all_of.3.0.json
+++ b/swagger_parser/test/e2e/tests/xof/nullable_sibling_all_of.3.0/nullable_sibling_all_of.3.0.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "API", "description": "API description", "version": "1.0" },
+  "paths": {
+    "/composition": {
+      "get": {
+        "operationId": "getComposition",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompositionDto" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ItemDto": {
+        "type": "object",
+        "properties": { "id": { "type": "string" } },
+        "required": ["id"]
+      },
+      "CompositionDto": {
+        "type": "object",
+        "properties": {
+          "nullableAllOf": {
+            "description": "OpenAPI 3.0 style: sibling nullable:true next to a single-element allOf",
+            "nullable": true,
+            "type": "object",
+            "allOf": [{ "$ref": "#/components/schemas/ItemDto" }]
+          },
+          "nullableOneOf": {
+            "description": "OpenAPI 3.1 style: oneOf with an explicit null branch (already supported)",
+            "oneOf": [
+              { "$ref": "#/components/schemas/ItemDto" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "required": ["nullableAllOf", "nullableOneOf"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

OpenAPI 3.0 expresses a nullable composed type with a `nullable: true` sibling next to a **single-element** `allOf` / `oneOf` / `anyOf`:

```yaml
field:
  nullable: true
  type: object
  allOf:
    - $ref: '#/components/schemas/Foo'
```

swagger_parser generates this field as **non-nullable** (`Foo` instead of `Foo?`).

The equivalent OpenAPI 3.1 form already works:

```yaml
field:
  oneOf:
    - $ref: '#/components/schemas/Foo'
    - type: null
```

## Root cause

In `_findType` (`open_api_parser.dart`), the `allOf`/`oneOf`/`anyOf` branch splits on element count:

- **Multi-element** (`oneOf: [{$ref}, {type: null}]`): the `{type: null}` member is detected and `makeNullable` is applied. This branch also already honors a sibling `nullable: true`.
- **Single-element** (`allOf: [{$ref}]`): it returns the inner ref type verbatim. The inner ref's own `nullable` is `false`, and the final nullability resolution (`ofType?.nullable ?? map[nullable] ?? …`) short-circuits on that non-null `false`, so the outer `nullable: true` is never consulted.

Same intent, different element count, different code path — which is why the 3.1 two-element form works but the 3.0 single-element sibling form does not.

## Fix

Apply `makeNullable` in the single-element branch when the outer schema carries `nullable: true`, mirroring what the multi-element branch already does.

## Tests

Adds an e2e regression test `xof/nullable_sibling_all_of.3.0` covering both the 3.0 single-element sibling form and the 3.1 `oneOf` + `type: null` form. Also updates the existing `all_of.3.0` expected output, whose `getUserById` response is `{nullable: true, allOf: [{$ref: UserDto}]}` and had silently captured the same bug — now correctly `Future<UserDto?>`. Full suite passes; `dart format` and `dart analyze` clean.
