### PR TITLE
Fix crash on multipart body referencing a schema without properties

### DIFF
--- a/swagger_parser/CHANGELOG.md
+++ b/swagger_parser/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.44.0
 
 - Add `preserve_schema_casing` option to preserve original casing of schema-derived identifiers, defaults to `false` for backwards compatibility, which normalises to PascalCase
+- Fix crash when a `multipart/form-data` request body references a schema without `properties`
 
 ## 1.43.1
 - Fix escaping `$unknown` in generated enum `toJson` error messages

--- a/swagger_parser/lib/src/parser/parser/open_api_parser.dart
+++ b/swagger_parser/lib/src/parser/parser/open_api_parser.dart
@@ -390,7 +390,9 @@ class OpenApiParser {
                 as Map<String, dynamic>;
             final schemes = components[_schemasConst] as Map<String, dynamic>;
             final dataClass = schemes[type] as Map<String, dynamic>;
-            final props = dataClass[_propertiesConst] as Map<String, dynamic>;
+            final props =
+                (dataClass[_propertiesConst] as Map<String, dynamic>?) ??
+                    <String, dynamic>{};
             final required = dataClass[_requiredConst] as List<dynamic>?;
 
             properties = props;

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -103,7 +103,22 @@ void main() {
       );
     });
 
-    // https://github.com/Carapacik/swagger_parser/issues/223
+    // https://github.com/Carapacik/swagger_parser/issues/466
+    test('multipart_request_with_ref_no_properties', () async {
+      await e2eTest(
+        'multipart_request_with_ref_no_properties',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.freezed,
+          putClientsInFolder: true,
+          includeIfNull: true,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
+
+    // https://github.com/Carapacik/swagger_parser/issues/444
     test('corrector', () async {
       await e2eTest(
         'corrector',

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/clients/fallback_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/clients/fallback_client.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'fallback_client.g.dart';
+
+@RestApi()
+abstract class FallbackClient {
+  factory FallbackClient(Dio dio, {String? baseUrl}) = _FallbackClient;
+
+  /// import with an empty multipart body
+  @MultiPart()
+  @POST('/multipart/request/empty-ref')
+  Future<String> postMultipartRequestEmptyRef();
+}

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/export.dart
@@ -1,0 +1,8 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/fallback_client.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/expected_files/rest_client.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/fallback_client.dart';
+
+/// API `v1.0.0`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '1.0.0';
+
+  FallbackClient? _fallback;
+
+  FallbackClient get fallback =>
+      _fallback ??= FallbackClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/multipart_request_with_ref_no_properties/openapi.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: API
+  version: 1.0.0
+paths:
+  /multipart/request/empty-ref:
+    post:
+      summary: import with an empty multipart body
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EmptyRequest'
+      responses:
+        '200':
+          description: dummy
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    EmptyRequest:
+      type: object


### PR DESCRIPTION
## What

Fixes #466

`swagger_parser` crashes (aborting the whole generation) when an endpoint declares a `multipart/form-data` request body that references (via `\$ref`) an object schema **without** a `properties` field.

`type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast` at `OpenApiParser.parseRestClients.parametersV3`.

## Root cause

The multipart `\$ref` branch assumes the referenced schema always has `properties`, while the inline (non-`\$ref`) branch already tolerates a missing `properties` map (`properties = {}`). This makes the `\$ref` branch consistent with the inline one.

## Reproducer (real-world)

An ASP.NET Core / FastEndpoints file-import endpoint whose request DTO is an empty placeholder while the file is read from the stream emits a multipart body referencing an empty object schema (`{ "type": "object" }`), e.g. `POST /api/admin/team-schedule/import` → `EmptyRequest`. Today this wipes the entire generated client because `make gen` removes `lib/src` first and `swagger_parser` exits `0` despite the error.

## Changes

- `open_api_parser.dart`: null-guard `properties` in the multipart `\$ref` branch (treat as empty form, like the inline branch).
- Added e2e test `multipart_request_with_ref_no_properties`.
- CHANGELOG entry.

## Checklist

- [x] `dart format .`
- [x] `dart analyze` — no issues
- [x] `dart test` — all tests pass (423 passed, 2 pre-existing skips)