### PR TITLE
fix: quote non-identifier dart_mappable enum values for nullable/list types

### DIFF
--- a/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
+++ b/swagger_parser/lib/src/generator/templates/dart_enum_dto_template.dart
@@ -141,6 +141,27 @@ String _fromJson(String className, UniversalEnumClass enumClass) => '''
       );
 ''';
 
+/// Computes the Dart literal for an enum item's JSON value.
+///
+/// String values (and any non-numeric value) are wrapped in quotes so the
+/// generated code is a valid constant expression. Numbers are emitted as-is.
+/// The [type] can be a plain type like `string`/`integer` or a JSON Schema
+/// type list such as `[string, null]`, in which case the value is quoted
+/// unless it is purely numeric.
+String? _enumJsonValue(String type, String? protectedJsonKey) {
+  if (type == 'string') {
+    return "'$protectedJsonKey'";
+  }
+  if (protectedJsonKey?.isEmpty ?? true) {
+    return "''";
+  }
+  if (protectedJsonKey == 'null') {
+    return null;
+  }
+  final isNumber = RegExp(r'^-?\d+(\.\d+)?$').hasMatch(protectedJsonKey ?? '');
+  return isNumber ? protectedJsonKey : "'$protectedJsonKey'";
+}
+
 String _enumValue(
   int index,
   String type,
@@ -149,27 +170,7 @@ String _enumValue(
 }) {
   final protectedJsonKey = protectJsonKey(item.jsonKey);
 
-  final String? value;
-  if (type == 'string') {
-    value = "'$protectedJsonKey'";
-  } else {
-    if (protectedJsonKey?.isEmpty ?? true) {
-      value = "''";
-    } else {
-      if (protectedJsonKey == 'null') {
-        value = null;
-      } else {
-        final isNumber = RegExp(
-          r'^-?\d+(\.\d+)?$',
-        ).hasMatch(protectedJsonKey ?? '');
-        if (isNumber) {
-          value = protectedJsonKey;
-        } else {
-          value = "'$protectedJsonKey'";
-        }
-      }
-    }
-  }
+  final value = _enumJsonValue(type, protectedJsonKey);
 
   final name = item.name.isEmpty ? 'empty' : item.name;
   return '''
@@ -184,8 +185,9 @@ String _enumValueDartMappable(
   required bool jsonParam,
 }) {
   final protectedJsonKey = protectJsonKey(item.jsonKey);
+  final value = _enumJsonValue(type, protectedJsonKey);
   return '''
-${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}${indentation(2)}@MappableValue(${type == 'string' ? "'$protectedJsonKey'" : protectedJsonKey}) 
+${index != 0 ? '\n' : ''}${descriptionComment(item.description, tab: '  ')}${indentation(2)}@MappableValue($value)
 ${indentation(2)}${item.name.toCamel}''';
 }
 

--- a/swagger_parser/test/e2e/e2e_test.dart
+++ b/swagger_parser/test/e2e/e2e_test.dart
@@ -75,6 +75,19 @@ void main() {
         schemaFileName: 'openapi.yaml',
       );
     });
+    test('enum_types_list_mappable', () async {
+      await e2eTest(
+        'enum_types_list_mappable',
+        (outputDirectory, schemaPath) => SWPConfig(
+          outputDirectory: outputDirectory,
+          schemaPath: schemaPath,
+          jsonSerializer: JsonSerializer.dartMappable,
+          putClientsInFolder: true,
+          enumsParentPrefix: false,
+        ),
+        schemaFileName: 'openapi.yaml',
+      );
+    });
     test('multipart_request_properties', () async {
       await e2eTest(
         'multipart_request_properties',

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/clients/api_client.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/clients/api_client.dart
@@ -1,0 +1,34 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/credential_types.dart';
+import '../models/enum_class.dart';
+import '../models/enum_class_dynamic.dart';
+import '../models/nullable_enum_in_object.dart';
+
+part 'api_client.g.dart';
+
+@RestApi()
+abstract class ApiClient {
+  factory ApiClient(Dio dio, {String? baseUrl}) = _ApiClient;
+
+  /// [enumClass] - description.
+  ///
+  /// [enumClassDynamic] - description.
+  ///
+  /// [credentialTypes] - description.
+  @GET('/api/v1/category/')
+  Future<void> apiV1CategoryList({
+    @Query('enum_class') required List<EnumClass?> enumClass,
+    @Query('enum_class_dynamic')
+    required List<EnumClassDynamic> enumClassDynamic,
+    @Query('nullable_enum_in_object')
+    required NullableEnumInObject nullableEnumInObject,
+    @Query('credentialTypes')
+    List<CredentialTypes>? credentialTypes = const [apple],
+  });
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/export.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/export.dart
@@ -1,0 +1,14 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+// Clients
+export 'clients/api_client.dart';
+// Data classes
+export 'models/nullable_enum_in_object.dart';
+export 'models/enum_class.dart';
+export 'models/enum_class_dynamic.dart';
+export 'models/fruits.dart';
+export 'models/credential_types.dart';
+// Root client
+export 'rest_client.dart';

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/credential_types.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/credential_types.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'credential_types.mapper.dart';
+
+@MappableEnum(defaultValue: CredentialTypes.unknown)
+enum CredentialTypes {
+  @MappableValue('apple')
+  apple,
+
+  @MappableValue('orange')
+  orange,
+
+  @MappableValue('unknown')
+  unknown;
+
+  @override
+  String toString() => toValue().toString();
+
+  /// Returns all defined enum values excluding the unknown value.
+  static List<CredentialTypes> get $valuesDefined =>
+      values.where((value) => value != CredentialTypes.unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/enum_class.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/enum_class.dart
@@ -1,0 +1,73 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'enum_class.mapper.dart';
+
+@MappableEnum(defaultValue: EnumClass.unknown)
+enum EnumClass {
+  /// The name has been replaced because it contains a keyword. Original name: `-index`.
+  @MappableValue('-index')
+  valueMinusIndex,
+
+  @MappableValue('-name')
+  minusName,
+
+  /// The name has been replaced because it contains a keyword. Original name: `index`.
+  @MappableValue('index')
+  valueIndex,
+
+  @MappableValue('name')
+  name,
+
+  /// The name has been replaced because it contains a keyword. Original name: `json`.
+  @MappableValue('json')
+  valueJson,
+
+  @MappableValue('yaml')
+  yaml,
+
+  @MappableValue(-1)
+  valueMinus1,
+
+  @MappableValue(0)
+  value0,
+
+  @MappableValue(1)
+  value1,
+
+  @MappableValue('1itemOne')
+  value1itemOne,
+
+  @MappableValue('2ItemTwo')
+  value2ItemTwo,
+
+  @MappableValue('3item_three')
+  value3itemThree,
+
+  @MappableValue('4ITEM-FOUR')
+  value4itemFour,
+
+  /// Incorrect name has been replaced. Original name: `5иллегалчарактер`.
+  @MappableValue('5иллегалчарактер')
+  undefined0,
+
+  @MappableValue('6 item six')
+  value6ItemSix,
+
+  /// The name has been replaced because it contains a keyword. Original name: `null`.
+  @MappableValue(null)
+  valueNull,
+
+  @MappableValue('unknown')
+  unknown;
+
+  @override
+  String toString() => toValue().toString();
+
+  /// Returns all defined enum values excluding the unknown value.
+  static List<EnumClass> get $valuesDefined =>
+      values.where((value) => value != EnumClass.unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/enum_class_dynamic.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/enum_class_dynamic.dart
@@ -1,0 +1,69 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'enum_class_dynamic.mapper.dart';
+
+@MappableEnum(defaultValue: EnumClassDynamic.unknown)
+enum EnumClassDynamic {
+  /// The name has been replaced because it contains a keyword. Original name: `-index`.
+  @MappableValue('-index')
+  valueMinusIndex,
+
+  @MappableValue('-name')
+  minusName,
+
+  /// The name has been replaced because it contains a keyword. Original name: `index`.
+  @MappableValue('index')
+  valueIndex,
+
+  @MappableValue('name')
+  name,
+
+  /// The name has been replaced because it contains a keyword. Original name: `json`.
+  @MappableValue('json')
+  valueJson,
+
+  @MappableValue('yaml')
+  yaml,
+
+  @MappableValue(-1)
+  valueMinus1,
+
+  @MappableValue(0)
+  value0,
+
+  @MappableValue(1)
+  value1,
+
+  @MappableValue('1itemOne')
+  value1itemOne,
+
+  @MappableValue('2ItemTwo')
+  value2ItemTwo,
+
+  @MappableValue('3item_three')
+  value3itemThree,
+
+  @MappableValue('4ITEM-FOUR')
+  value4itemFour,
+
+  /// Incorrect name has been replaced. Original name: `5иллегалчарактер`.
+  @MappableValue('5иллегалчарактер')
+  undefined0,
+
+  @MappableValue('6 item six')
+  value6ItemSix,
+
+  @MappableValue('unknown')
+  unknown;
+
+  @override
+  String toString() => toValue().toString();
+
+  /// Returns all defined enum values excluding the unknown value.
+  static List<EnumClassDynamic> get $valuesDefined =>
+      values.where((value) => value != EnumClassDynamic.unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/fruits.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/fruits.dart
@@ -1,0 +1,30 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'fruits.mapper.dart';
+
+@MappableEnum(defaultValue: Fruits.unknown)
+enum Fruits {
+  @MappableValue('apple')
+  apple,
+
+  @MappableValue('orange')
+  orange,
+
+  /// The name has been replaced because it contains a keyword. Original name: `null`.
+  @MappableValue(null)
+  valueNull,
+
+  @MappableValue('unknown')
+  unknown;
+
+  @override
+  String toString() => toValue().toString();
+
+  /// Returns all defined enum values excluding the unknown value.
+  static List<Fruits> get $valuesDefined =>
+      values.where((value) => value != Fruits.unknown).toList();
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/nullable_enum_in_object.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/models/nullable_enum_in_object.dart
@@ -1,0 +1,21 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'fruits.dart';
+
+part 'nullable_enum_in_object.mapper.dart';
+
+@MappableClass()
+class NullableEnumInObject with NullableEnumInObjectMappable {
+  const NullableEnumInObject({
+    this.fruits,
+  });
+  final Fruits? fruits;
+
+  static NullableEnumInObject fromJson(Map<String, dynamic> json) =>
+      NullableEnumInObjectMapper.ensureInitialized()
+          .decodeMap<NullableEnumInObject>(json);
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/rest_client.dart
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/expected_files/rest_client.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_import, invalid_annotation_target, unnecessary_import
+
+import 'package:dio/dio.dart';
+
+import 'clients/api_client.dart';
+
+///  `v0.0.0 (v1)`
+class RestClient {
+  RestClient(
+    Dio dio, {
+    String? baseUrl,
+  })  : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  static String get version => '0.0.0 (v1)';
+
+  ApiClient? _api;
+
+  ApiClient get api => _api ??= ApiClient(_dio, baseUrl: _baseUrl);
+}

--- a/swagger_parser/test/e2e/tests/enum_types_list_mappable/openapi.yaml
+++ b/swagger_parser/test/e2e/tests/enum_types_list_mappable/openapi.yaml
@@ -1,0 +1,95 @@
+openapi: 3.1.0
+info:
+  title: ""
+  version: 0.0.0 (v1)
+paths:
+  /api/v1/category/:
+    get:
+      operationId: api_v1_category_list
+      parameters:
+        - in: query
+          name: enum_class
+          required: true
+          schema:
+            type: array
+            items:
+              type:
+                - string
+                - null
+              enum:
+                - -index
+                - -name
+                - index
+                - name
+                - json
+                - yaml
+                - -1
+                - 0
+                - "1"
+                - "1itemOne"
+                - "2ItemTwo"
+                - "3item_three"
+                - "4ITEM-FOUR"
+                - "5иллегалчарактер"
+                - "6 item six"
+                - null
+          description: "description"
+        - in: query
+          name: enum_class_dynamic
+          required: true
+          schema:
+            type: array
+            items:
+              type:
+                - string
+                - integer
+              enum:
+                - -index
+                - -name
+                - index
+                - name
+                - json
+                - yaml
+                - -1
+                - 0
+                - "1"
+                - "1itemOne"
+                - "2ItemTwo"
+                - "3item_three"
+                - "4ITEM-FOUR"
+                - "5иллегалчарактер"
+                - "6 item six"
+          description: "description"
+        - in: query
+          name: nullable_enum_in_object
+          required: true
+          schema:
+            type: object
+            properties:
+              fruits:
+                type:
+                  - string
+                  - "null"
+                enum:
+                  - apple
+                  - orange
+                  - null
+        - name: credentialTypes
+          in: query
+          required: false
+          allowReserved: true
+          schema:
+            type: array
+            default: [ apple ]
+            minItems: 1
+            items:
+              enum:
+                - apple
+                - orange
+
+          description: "description"
+      tags:
+        - api
+      responses:
+        "204":
+          description: ""


### PR DESCRIPTION
This PR fixes enum generation for dart_mappable when an enum's schema uses a JSON Schema type list such as `["string", "null"]` (common in OpenAPI 3.1 specs, e.g. those generated from Laravel form request rules).

## Problem

Generated dart_mappable enums were emitting the JSON value as a **bare identifier** instead of a string literal:

```dart
@MappableValue(hidden_gem)
hiddenGem,

@MappableValue(price_asc)
priceAsc,
```

`@MappableValue(...)` requires a **constant expression**, so an unquoted identifier like `hidden_gem` or `price_asc` is not valid Dart. The generated file fails to compile with:

> Arguments of a constant creation must be constant expressions.

This only happened for enum values that are not valid Dart identifiers (contain underscores, dashes, digits, etc.) when the enum type was declared as a nullable/list type.

## Root cause

The dart_mappable enum template only wrapped values in quotes when the enum's parsed type was **exactly** `'string'`:

```dart
@MappableValue(${type == 'string' ? "'$protectedJsonKey'" : protectedJsonKey})
```

When a schema declares:

```json
"sort": {
  "type": ["string", "null"],
  "enum": ["rating", "name", "price_asc", "price_desc"]
}
```

the parser stores the enum type as the literal string `"[string, null]"` — not `"string"`. (This is intentional: the nullability is preserved in the type string so `toDartType()` can derive `String?` for the JSON field.) Because `"[string, null]" != "string"`, the condition was false and the value was emitted unquoted.

The freezed / json_serializable template already handled this correctly by falling back to quoting any non-numeric value. The dart_mappable template was missing that fallback.

## Example

This schema:

```json
"sort": {
  "type": ["string", "null"],
  "enum": ["rating", "name", "price_asc", "price_desc"]
}
```

previously generated (invalid):

```dart
@MappableEnum(defaultValue: Sort2.unknown)
enum Sort2 {
  @MappableValue(rating)
  rating,
  @MappableValue(name)
  name,
  @MappableValue(price_asc)
  priceAsc,
  @MappableValue(price_desc)
  priceDesc,
  @MappableValue(unknown)
  unknown;
  ...
}
```

## Fix

The value-literal logic is now shared between the freezed and dart_mappable templates via a single helper. It quotes strings and any non-numeric value, leaves numeric values bare, and keeps `null` as `null`:

```dart
@MappableEnum(defaultValue: Sort2.unknown)
enum Sort2 {
  @MappableValue('rating')
  rating,
  @MappableValue('name')
  name,
  @MappableValue('price_asc')
  priceAsc,
  @MappableValue('price_desc')
  priceDesc,
  @MappableValue('unknown')
  unknown;
  ...
}
```

Behavior after the fix:

- String / non-identifier values → quoted: `@MappableValue('price_asc')`, `@MappableValue('hidden_gem')`
- Numeric enum values → bare: `@MappableValue(0)`, `@MappableValue(-1)`
- Null values → `@MappableValue(null)`

This restores valid, compilable dart_mappable output for enums declared with nullable/list types.

## Tests

Added a new e2e test `enum_types_list_mappable` (a dart_mappable variant of the existing `enum_types_list` fixture) that covers `["string", "null"]`, `["string", "integer"]`, and enum properties nested inside objects. The full e2e suite and generator/parser unit tests pass.
